### PR TITLE
Support minimal get_players payload

### DIFF
--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -1,7 +1,7 @@
 """Define consts for the pyheos package."""
 
 __title__ = "pyheos"
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 CLI_PORT = 1255
 DEFAULT_TIMEOUT = 10.0

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -192,9 +192,12 @@ class HeosPlayer:
         self._player_id = parse_player_id(data)
         self._model = data['model']
         self._version = parse_player_version(data)
-        self._ip_address = data['ip']
-        self._network = data['network']
-        self._line_out = int(data['lineout'])
+        self._ip_address = data.get('ip')
+        self._network = data.get('network')
+        try:
+            self._line_out = int(data.get('lineout'))
+        except (TypeError, ValueError):
+            pass
         self._available = True
 
     def set_available(self, available):

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -23,6 +23,18 @@ def test_str():
     assert repr(player) == '{Back Patio (HEOS Drive) with id 1 at 192.168.0.1}'
 
 
+def test_init_minimal_data():
+    """Test the init function."""
+    data = {
+        "name": "Back Patio",
+        "pid": 1,
+        "model": "HEOS Drive"
+    }
+    player = HeosPlayer(Heos('None'), data)
+    assert str(player) == '{Back Patio (HEOS Drive)}'
+    assert repr(player) == '{Back Patio (HEOS Drive) with id 1 at None}'
+
+
 @pytest.mark.asyncio
 async def test_set_state(mock_device, heos):
     """Test the play, pause, and stop commands."""


### PR DESCRIPTION
## Description:
Support minimal payload in `get_players` response.

**Related issue (if applicable):** home-assistant/home-assistant#23557

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.