### PR TITLE
Release 0.5.2

### DIFF
--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -1,7 +1,7 @@
 """Define consts for the pyheos package."""
 
 __title__ = "pyheos"
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 CLI_PORT = 1255
 DEFAULT_TIMEOUT = 10.0

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -45,18 +45,24 @@ class HeosNowPlayingMedia:
 
     def from_data(self, data: dict):
         """Update the attributes from the supplied data."""
-        self._type = data['type']
-        self._song = data['song']
+        self._type = data.get('type')
+        self._song = data.get('song')
         self._station = data.get('station')
-        self._album = data['album']
-        self._artist = data['artist']
-        self._image_url = data['image_url']
-        self._album_id = data['album_id']
-        self._media_id = data['mid']
-        self._queue_id = int(data['qid'])
-        self._source_id = int(data['sid'])
+        self._album = data.get('album')
+        self._artist = data.get('artist')
+        self._image_url = data.get('image_url')
+        self._album_id = data.get('album_id')
+        self._media_id = data.get('mid')
+        try:
+            self._queue_id = int(data.get('qid'))
+        except (TypeError, ValueError):
+            self._queue_id = None
+        try:
+            self._source_id = int(data.get('sid'))
+        except (TypeError, ValueError):
+            self._source_id = None
 
-        supported_controls = const.CONTROLS_ALL
+        supported_controls = const.CONTROLS_ALL if self._source_id else []
         controls = const.SOURCE_CONTROLS.get(self._source_id)
         if controls:
             supported_controls = controls.get(self._type, supported_controls)

--- a/tests/fixtures/player.get_now_playing_media_blank.json
+++ b/tests/fixtures/player.get_now_playing_media_blank.json
@@ -1,0 +1,9 @@
+{
+	"heos": {
+		"command": "player/get_now_playing_media",
+		"result": "success",
+		"message": "pid=1"
+	},
+	"payload": {},
+	"options": []
+}

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -366,3 +366,22 @@ async def test_add_to_queue_track(mock_device, heos):
     mock_device.register(const.COMMAND_BROWSE_ADD_TO_QUEUE, args,
                          'browse.add_to_queue_track')
     await player.add_to_queue(source, const.ADD_QUEUE_PLAY_NOW)
+
+
+@pytest.mark.asyncio
+async def test_now_playing_media_unavailable(mock_device, heos):
+    """Test edge where now_playing_media returns an empty payload."""
+    await heos.get_players()
+    player = heos.players.get(1)
+    mock_device.register(const.COMMAND_GET_NOW_PLAYING_MEDIA, None,
+                         'player.get_now_playing_media_blank', replace=True)
+    await player.refresh_now_playing_media()
+    assert player.now_playing_media.supported_controls == []
+    assert player.now_playing_media.type is None
+    assert player.now_playing_media.song is None
+    assert player.now_playing_media.station is None
+    assert player.now_playing_media.album is None
+    assert player.now_playing_media.artist is None
+    assert player.now_playing_media.image_url is None
+    assert player.now_playing_media.album_id is None
+    assert player.now_playing_media.media_id is None


### PR DESCRIPTION
## Description:
- Fix edge case where `get_now_playing_media` returns an empty payload

**Related issue (if applicable):** source home-assistant/home-assistant#23640

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.