### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author="Andrew Sayre",
     author_email="andrew@sayre.net",
     license="ASL 2.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests", "tests.*")),
     install_requires=[],
     tests_require=["tox>=3.5.0,<4.0.0"],
     platforms=["any"],


### PR DESCRIPTION
## Description:

Installing tests is generally not desirable in the first place, but particularly not in the global top level `tests` package.

**Related issue (if applicable):** fixes #<pyheos issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [ ] `README.MD` updated (if necessary)