### PR TITLE
Stability improvement with Home Assistant

### DIFF
--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -277,12 +277,7 @@ class HeosConnection:
             self._writer.write((uri + SEPARATOR).encode())
             await self._writer.drain()
             response = await asyncio.wait_for(event.wait(), self.timeout)
-        except (
-            ConnectionError,
-            asyncio.TimeoutError,
-            OSError,
-            AttributeError,
-        ) as error:
+        except (ConnectionError, asyncio.TimeoutError, OSError) as error:
             # Occurs when the connection breaks
             asyncio.ensure_future(self._handle_connection_error(error))
             message = format_error_message(error)

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -265,6 +265,7 @@ class HeosConnection:
         await self._lock.acquire()
 
         if self._state != const.STATE_CONNECTED:
+            self._lock.release()
             _LOGGER.debug(
                 "Command failed '%s': %s", masked_uri, "Not connected to device"
             )

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -176,8 +176,6 @@ class HeosConnection:
                 return
             except HeosError as err:
                 # Occurs when we could not reconnect
-                # Set state to reconnecting since _connect may have set it to connected and failed after
-                self._state = const.STATE_RECONNECTING
                 _LOGGER.debug("Failed to reconnect to %s: %s", self.host, err)
                 await self._disconnect()
                 await asyncio.sleep(self._reconnect_delay)

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -262,6 +262,8 @@ class HeosConnection:
             const.BASE_URI, command, _encode_query(params, mask=True)
         )
 
+        await self._lock.acquire()
+
         if self._state != const.STATE_CONNECTED:
             _LOGGER.debug(
                 "Command failed '%s': %s", masked_uri, "Not connected to device"
@@ -272,7 +274,6 @@ class HeosConnection:
         event = ResponseEvent(sequence)
         self._pending_commands[command].append(event)
         # Send command
-        await self._lock.acquire()
         try:
             self._writer.write((uri + SEPARATOR).encode())
             await self._writer.drain()

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -176,6 +176,8 @@ class HeosConnection:
                 return
             except HeosError as err:
                 # Occurs when we could not reconnect
+                # Set state to reconnecting since _connect may have set it to connected and failed after
+                self._state = const.STATE_RECONNECTING
                 _LOGGER.debug("Failed to reconnect to %s: %s", self.host, err)
                 await self._disconnect()
                 await asyncio.sleep(self._reconnect_delay)
@@ -275,7 +277,12 @@ class HeosConnection:
             self._writer.write((uri + SEPARATOR).encode())
             await self._writer.drain()
             response = await asyncio.wait_for(event.wait(), self.timeout)
-        except (ConnectionError, asyncio.TimeoutError, OSError) as error:
+        except (
+            ConnectionError,
+            asyncio.TimeoutError,
+            OSError,
+            AttributeError,
+        ) as error:
             # Occurs when the connection breaks
             asyncio.ensure_future(self._handle_connection_error(error))
             message = format_error_message(error)


### PR DESCRIPTION
## Description:
Lock functions added such that only one command is sent and processed at the heos device before next command is sent. This improves stability when used with the HA integration hugely. From usually being disconnected randomly after 1-24 hours it has now yet to fail for me after several weeks of service.

See also  https://github.com/andrewsayre/pyheos/pull/29 for additional stability improvements.

**Related issue (if applicable):** fixes #20 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [N/A] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [N/A] `README.MD` updated (if necessary)