### PR TITLE
Fix for incorrect connection status

### DIFF
--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -175,6 +175,8 @@ class HeosConnection:
                 return
             except HeosError as err:
                 # Occurs when we could not reconnect
+                # Set state to reconnecting since _connect may have set it to connected and failed after
+                self._state = const.STATE_RECONNECTING
                 _LOGGER.debug("Failed to reconnect to %s: %s", self.host, err)
                 await self._disconnect()
                 await asyncio.sleep(self._reconnect_delay)

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -275,7 +275,12 @@ class HeosConnection:
             self._writer.write((uri + SEPARATOR).encode())
             await self._writer.drain()
             response = await asyncio.wait_for(event.wait(), self.timeout)
-        except (ConnectionError, asyncio.TimeoutError, OSError) as error:
+        except (
+            ConnectionError,
+            asyncio.TimeoutError,
+            OSError,
+            AttributeError,
+        ) as error:
             # Occurs when the connection breaks
             asyncio.ensure_future(self._handle_connection_error(error))
             message = format_error_message(error)


### PR DESCRIPTION
## Description:
Reconnect logic improved, it could fail because the state was set to connected before the connect function had called the register_for_change_events function, and if that failed an error was raised and the state remained connected while it was actually not really. So state is set back to reconnecting in _reconnect when this happens.
Also catching AttributeError in command function which sometimes occurs when _writer object is None (which can happen sometimes during reconnect process).

See also https://github.com/andrewsayre/pyheos/pull/21 for additional stability improvements.

**Related issue (if applicable):** fixes #20 
