### PR TITLE
Add feature to test a connection and obtain system info

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This class encapsulates the options and configuration for connecting to a HEOS s
 - `timeout: float`: The timeout in seconds for opening a connectoin and issuing commands to the device. Default is `pyheos.const.DEFAULT_TIMEOUT = 10.0`. This parameter is required.
 - `heart_beat: bool`: Set to `True` to enable heart beat messages, `False` to disable. Used in conjunction with `heart_beat_delay`. The default is `True`.
 - `heart_beat_interval: float`: The interval in seconds between heart beat messages. Used in conjunction with `heart_beat`. Default is `pyheos.const.DEFAULT_HEART_BEAT = 10.0`
+- `events: bool`: Set to `True` to enable event updates, `False` to disable. The default is `True`.
 - `all_progress_events: bool`: Set to `True` to receive media progress events, `False` to only receive media changed events. The default is `True`.
 - `dispatcher: pyheos.Dispatcher | None`: The dispatcher instance to use for event callbacks. If not provided, an internally created instance will be used.
 - `auto_reconnect: bool`: Set to `True` to automatically reconnect if the connection is lost. The default is `False`. Used in conjunction with `auto_reconnect_delay`.

--- a/pyheos/command.py
+++ b/pyheos/command.py
@@ -54,7 +54,7 @@ class HeosCommands:
 
     async def get_player_state(self, player_id: int) -> str:
         """Get the state of the player."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_PLAY_STATE, params)
         )
@@ -64,14 +64,14 @@ class HeosCommands:
         """Set the state of the player."""
         if state not in const.VALID_PLAY_STATES:
             raise ValueError("Invalid play state: " + state)
-        params = {"pid": player_id, "state": state}
+        params = {const.ATTR_PLAYER_ID: player_id, "state": state}
         await self._connection.command(
             HeosCommand(const.COMMAND_SET_PLAY_STATE, params)
         )
 
     async def get_now_playing_state(self, player_id: int) -> dict[str, Any]:
         """Get the now playing media information."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_NOW_PLAYING_MEDIA, params)
         )
@@ -80,7 +80,7 @@ class HeosCommands:
 
     async def get_volume(self, player_id: int) -> int:
         """Get the volume of the player."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_VOLUME, params)
         )
@@ -90,12 +90,12 @@ class HeosCommands:
         """Set the volume of the player."""
         if level < 0 or level > 100:
             raise ValueError("'level' must be in the range 0-100")
-        params = {"pid": player_id, "level": level}
+        params = {const.ATTR_PLAYER_ID: player_id, "level": level}
         await self._connection.command(HeosCommand(const.COMMAND_SET_VOLUME, params))
 
     async def get_mute(self, player_id: int) -> bool:
         """Get the mute state of the player."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_MUTE, params)
         )
@@ -103,31 +103,31 @@ class HeosCommands:
 
     async def set_mute(self, player_id: int, state: bool) -> None:
         """Set the mute state of the player."""
-        params = {"pid": player_id, "state": "on" if state else "off"}
+        params = {const.ATTR_PLAYER_ID: player_id, "state": "on" if state else "off"}
         await self._connection.command(HeosCommand(const.COMMAND_SET_MUTE, params))
 
     async def volume_up(self, player_id: int, step: int = const.DEFAULT_STEP) -> None:
         """Increase the volume level."""
         if step < 1 or step > 10:
             raise ValueError("'step' must be in the range 1-10")
-        params = {"pid": player_id, "step": step}
+        params = {const.ATTR_PLAYER_ID: player_id, "step": step}
         await self._connection.command(HeosCommand(const.COMMAND_VOLUME_UP, params))
 
     async def volume_down(self, player_id: int, step: int = const.DEFAULT_STEP) -> None:
         """Increase the volume level."""
         if step < 1 or step > 10:
             raise ValueError("'step' must be in the range 1-10")
-        params = {"pid": player_id, "step": step}
+        params = {const.ATTR_PLAYER_ID: player_id, "step": step}
         await self._connection.command(HeosCommand(const.COMMAND_VOLUME_DOWN, params))
 
     async def toggle_mute(self, player_id: int) -> None:
         """Toggle the mute state.."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         await self._connection.command(HeosCommand(const.COMMAND_TOGGLE_MUTE, params))
 
     async def get_play_mode(self, player_id: int) -> tuple[str, bool]:
         """Get the current play mode."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_PLAY_MODE, params)
         )
@@ -140,7 +140,7 @@ class HeosCommands:
         if repeat not in const.VALID_REPEAT_MODES:
             raise ValueError("Invalid repeat mode: " + repeat)
         params = {
-            "pid": player_id,
+            const.ATTR_PLAYER_ID: player_id,
             "repeat": repeat,
             "shuffle": "on" if shuffle else "off",
         }
@@ -148,17 +148,17 @@ class HeosCommands:
 
     async def clear_queue(self, player_id: int) -> None:
         """Clear the queue."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         await self._connection.command(HeosCommand(const.COMMAND_CLEAR_QUEUE, params))
 
     async def play_next(self, player_id: int) -> None:
         """Play next."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         await self._connection.command(HeosCommand(const.COMMAND_PLAY_NEXT, params))
 
     async def play_previous(self, player_id: int) -> None:
         """Play next."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         await self._connection.command(HeosCommand(const.COMMAND_PLAY_PREVIOUS, params))
 
     async def get_music_sources(self) -> Sequence[dict]:
@@ -183,7 +183,7 @@ class HeosCommands:
         if input_name not in const.VALID_INPUTS:
             raise ValueError("Invalid input name: " + input_name)
         params = {
-            "pid": player_id,
+            const.ATTR_PLAYER_ID: player_id,
             "spid": source_player_id or player_id,
             "input": input_name,
         }
@@ -195,14 +195,14 @@ class HeosCommands:
         """Play the specified preset by 1-based index."""
         if preset < 1:
             raise ValueError("Invalid preset: " + str(preset))
-        params = {"pid": player_id, "preset": preset}
+        params = {const.ATTR_PLAYER_ID: player_id, "preset": preset}
         await self._connection.command(
             HeosCommand(const.COMMAND_BROWSE_PLAY_PRESET, params)
         )
 
     async def play_stream(self, player_id: int, url: str) -> None:
         """Play the specified URL."""
-        params = {"pid": player_id, "url": url}
+        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_URL: url}
         await self._connection.command(
             HeosCommand(const.COMMAND_BROWSE_PLAY_STREAM, params)
         )
@@ -219,7 +219,7 @@ class HeosCommands:
         if add_queue_option not in const.VALID_ADD_QUEUE_OPTIONS:
             raise ValueError(f"Invalid queue options: {add_queue_option}")
         params = {
-            "pid": player_id,
+            const.ATTR_PLAYER_ID: player_id,
             "sid": source_id,
             "cid": container_id,
             "aid": add_queue_option,
@@ -237,12 +237,12 @@ class HeosCommands:
 
     async def set_group(self, player_ids: Sequence[int]) -> None:
         """Create, modify, or ungroup players."""
-        params = {"pid": ",".join(map(str, player_ids))}
+        params = {const.ATTR_PLAYER_ID: ",".join(map(str, player_ids))}
         await self._connection.command(HeosCommand(const.COMMAND_SET_GROUP, params))
 
     async def get_group_volume(self, group_id: int) -> int:
         """Get the volume of a group."""
-        params = {"gid": group_id}
+        params = {const.ATTR_GROUP_ID: group_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_GROUP_VOLUME, params)
         )
@@ -250,7 +250,7 @@ class HeosCommands:
 
     async def get_group_mute(self, group_id: int) -> bool:
         """Get the mute status of the group."""
-        params = {"gid": group_id}
+        params = {const.ATTR_GROUP_ID: group_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_GROUP_MUTE, params)
         )
@@ -260,7 +260,7 @@ class HeosCommands:
         """Set the volume of the group."""
         if level < 0 or level > 100:
             raise ValueError("'level' must be in the range 0-100")
-        params = {"gid": group_id, "level": level}
+        params = {const.ATTR_GROUP_ID: group_id, "level": level}
         await self._connection.command(
             HeosCommand(const.COMMAND_SET_GROUP_VOLUME, params)
         )
@@ -271,7 +271,7 @@ class HeosCommands:
         """Increase the volume level."""
         if step < 1 or step > 10:
             raise ValueError("'step' must be in the range 1-10")
-        params = {"gid": group_id, "step": step}
+        params = {const.ATTR_GROUP_ID: group_id, "step": step}
         await self._connection.command(
             HeosCommand(const.COMMAND_GROUP_VOLUME_UP, params)
         )
@@ -282,21 +282,21 @@ class HeosCommands:
         """Increase the volume level."""
         if step < 1 or step > 10:
             raise ValueError("'step' must be in the range 1-10")
-        params = {"gid": group_id, "step": step}
+        params = {const.ATTR_GROUP_ID: group_id, "step": step}
         await self._connection.command(
             HeosCommand(const.COMMAND_GROUP_VOLUME_DOWN, params)
         )
 
     async def group_set_mute(self, group_id: int, state: bool) -> None:
         """Set the mute state of the group."""
-        params = {"gid": group_id, "state": "on" if state else "off"}
+        params = {const.ATTR_GROUP_ID: group_id, "state": "on" if state else "off"}
         await self._connection.command(
             HeosCommand(const.COMMAND_SET_GROUP_MUTE, params)
         )
 
     async def group_toggle_mute(self, group_id: int) -> None:
         """Toggle the mute state."""
-        params = {"gid": group_id}
+        params = {const.ATTR_GROUP_ID: group_id}
         await self._connection.command(
             HeosCommand(const.COMMAND_GROUP_TOGGLE_MUTE, params)
         )
@@ -305,7 +305,7 @@ class HeosCommands:
         """Play a quick select."""
         if quick_select_id < 1 or quick_select_id > 6:
             raise ValueError("'quick_select_id' must be in the range 1-6")
-        params = {"pid": player_id, "id": quick_select_id}
+        params = {const.ATTR_PLAYER_ID: player_id, "id": quick_select_id}
         await self._connection.command(
             HeosCommand(const.COMMAND_PLAY_QUICK_SELECT, params)
         )
@@ -314,14 +314,14 @@ class HeosCommands:
         """Play a quick select."""
         if quick_select_id < 1 or quick_select_id > 6:
             raise ValueError("'quick_select_id' must be in the range 1-6")
-        params = {"pid": player_id, "id": quick_select_id}
+        params = {const.ATTR_PLAYER_ID: player_id, "id": quick_select_id}
         await self._connection.command(
             HeosCommand(const.COMMAND_SET_QUICK_SELECT, params)
         )
 
     async def get_quick_selects(self, player_id: int) -> Sequence[dict]:
         """Play a quick select."""
-        params = {"pid": player_id}
+        params = {const.ATTR_PLAYER_ID: player_id}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_GET_QUICK_SELECTS, params)
         )

--- a/pyheos/command.py
+++ b/pyheos/command.py
@@ -22,24 +22,24 @@ class HeosCommands:
         await self._connection.command(
             HeosCommand(
                 const.COMMAND_REGISTER_FOR_CHANGE_EVENTS,
-                {const.PARAM_ENABLE: const.VALUE_ON if enable else const.VALUE_OFF},
+                {const.ATTR_ENABLE: const.VALUE_ON if enable else const.VALUE_OFF},
             )
         )
 
     async def check_account(self) -> Optional[str]:
         """Return the logged in username."""
         response = await self._connection.command(HeosCommands._account_check_command)
-        if const.PARAM_SIGNED_IN in response.message:
-            return response.get_message_value(const.PARAM_USER_NAME)
+        if const.ATTR_SIGNED_IN in response.message:
+            return response.get_message_value(const.ATTR_USER_NAME)
         return None
 
     async def sign_in(self, username: str, password: str) -> str:
         """Sign in to the HEOS account using the provided credential and return the user name."""
-        params = {const.PARAM_USER_NAME: username, const.PARAM_PASSWORD: password}
+        params = {const.ATTR_USER_NAME: username, const.ATTR_PASSWORD: password}
         response = await self._connection.command(
             HeosCommand(const.COMMAND_SIGN_IN, params)
         )
-        return response.get_message_value(const.PARAM_USER_NAME)
+        return response.get_message_value(const.ATTR_USER_NAME)
 
     async def sign_out(self) -> None:
         """Sign out of the HEOS account."""

--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -42,9 +42,11 @@ STATE_DISCONNECTED: Final = "disconnected"
 STATE_RECONNECTING: Final = "reconnecting"
 
 ATTR_IP_ADDRESS: Final = "ip"
+ATTR_LINE_OUT: Final = "lineout"
 ATTR_MODEL: Final = "model"
 ATTR_NAME: Final = "name"
 ATTR_NETWORK: Final = "network"
+ATTR_PLAYER_ID: Final = "pid"
 ATTR_SERIAL: Final = "serial"
 ATTR_VERSION: Final = "version"
 

--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -41,6 +41,17 @@ STATE_CONNECTED: Final = "connected"
 STATE_DISCONNECTED: Final = "disconnected"
 STATE_RECONNECTING: Final = "reconnecting"
 
+ATTR_IP_ADDRESS: Final = "ip"
+ATTR_MODEL: Final = "model"
+ATTR_NAME: Final = "name"
+ATTR_NETWORK: Final = "network"
+ATTR_SERIAL: Final = "serial"
+ATTR_VERSION: Final = "version"
+
+NETWORK_TYPE_WIRED: Final = "wired"
+NETWORK_TYPE_WIFI: Final = "wifi"
+NETWORK_TYPE_UNKNOWN: Final = "unknown"
+
 DATA_NEW: Final = "new"
 DATA_MAPPED_IDS: Final = "mapped_ids"
 

--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -9,23 +9,30 @@ DEFAULT_RECONNECT_ATTEMPTS: Final = 0  # Unlimited
 DEFAULT_HEART_BEAT: Final = 10.0
 DEFAULT_STEP: Final = 5
 
+ATTR_ENABLE: Final = "enable"
+ATTR_ERROR_ID: Final = "eid"
+ATTR_GROUP_ID: Final = "gid"
+ATTR_IP_ADDRESS: Final = "ip"
+ATTR_LINE_OUT: Final = "lineout"
+ATTR_MODEL: Final = "model"
+ATTR_NAME: Final = "name"
+ATTR_NETWORK: Final = "network"
+ATTR_PASSWORD: Final = "pw"
+ATTR_PLAYER_ID: Final = "pid"
+ATTR_SERIAL: Final = "serial"
+ATTR_SIGNED_OUT: Final = "signed_out"
+ATTR_SIGNED_IN: Final = "signed_in"
+ATTR_SYSTEM_ERROR_NUMBER: Final = "syserrno"
+ATTR_TEXT: Final = "text"
+ATTR_URL: Final = "url"
+ATTR_USER_NAME: Final = "un"
+ATTR_VERSION: Final = "version"
+
 QUOTE_MAP: Final = {"&": "%26", "=": "%3D", "%": "%25"}
-MASKED_PARAMS: Final = {"pw"}
+MASKED_PARAMS: Final = {ATTR_PASSWORD}
 MASK: Final = "********"
 SEPARATOR: Final = "\r\n"
 SEPARATOR_BYTES: Final = SEPARATOR.encode()
-
-PARAM_ENABLE: Final = "enable"
-PARAM_URL: Final = "url"
-PARAM_PLAYER_ID: Final = "pid"
-PARAM_GROUP_ID: Final = "gid"
-PARAM_USER_NAME: Final = "un"
-PARAM_PASSWORD: Final = "pw"
-PARAM_SIGNED_IN: Final = "signed_in"
-PARAM_SIGNED_OUT: Final = "signed_out"
-PARAM_ERROR_ID: Final = "eid"
-PARAM_TEXT: Final = "text"
-PARAM_SYSTEM_ERROR_NUMBER: Final = "syserrno"
 
 VALUE_ON: Final = "on"
 VALUE_OFF: Final = "off"
@@ -40,15 +47,6 @@ SYSTEM_ERROR_USER_NOT_FOUND: Final = -1056
 STATE_CONNECTED: Final = "connected"
 STATE_DISCONNECTED: Final = "disconnected"
 STATE_RECONNECTING: Final = "reconnecting"
-
-ATTR_IP_ADDRESS: Final = "ip"
-ATTR_LINE_OUT: Final = "lineout"
-ATTR_MODEL: Final = "model"
-ATTR_NAME: Final = "name"
-ATTR_NETWORK: Final = "network"
-ATTR_PLAYER_ID: Final = "pid"
-ATTR_SERIAL: Final = "serial"
-ATTR_VERSION: Final = "version"
 
 NETWORK_TYPE_WIRED: Final = "wired"
 NETWORK_TYPE_WIFI: Final = "wifi"

--- a/pyheos/error.py
+++ b/pyheos/error.py
@@ -66,12 +66,12 @@ class CommandFailedError(CommandError):
     @classmethod
     def from_message(cls, message: HeosMessage) -> "CommandFailedError":
         """Create a new instance of the error from a message."""
-        error_text = message.get_message_value(const.PARAM_TEXT)
+        error_text = message.get_message_value(const.ATTR_TEXT)
         system_error_number = None
-        error_id = message.get_message_value_int(const.PARAM_ERROR_ID)
+        error_id = message.get_message_value_int(const.ATTR_ERROR_ID)
         if error_id == const.ERROR_SYSTEM_ERROR:
             system_error_number = message.get_message_value_int(
-                const.PARAM_SYSTEM_ERROR_NUMBER
+                const.ATTR_SYSTEM_ERROR_NUMBER
             )
             error_text += f" {system_error_number}"
 

--- a/pyheos/group.py
+++ b/pyheos/group.py
@@ -27,7 +27,9 @@ def create_group(
             members.append(player)
     if leader is None:
         raise ValueError("No leader found in group")
-    return HeosGroup(heos, data[const.ATTR_NAME], int(data["gid"]), leader, members)
+    return HeosGroup(
+        heos, data[const.ATTR_NAME], int(data[const.ATTR_GROUP_ID]), leader, members
+    )
 
 
 class HeosGroup:

--- a/pyheos/group.py
+++ b/pyheos/group.py
@@ -27,7 +27,7 @@ def create_group(
             members.append(player)
     if leader is None:
         raise ValueError("No leader found in group")
-    return HeosGroup(heos, data["name"], int(data["gid"]), leader, members)
+    return HeosGroup(heos, data[const.ATTR_NAME], int(data["gid"]), leader, members)
 
 
 class HeosGroup:

--- a/pyheos/group.py
+++ b/pyheos/group.py
@@ -20,7 +20,7 @@ def create_group(
     leader = None
     members = []
     for group_player in data["players"]:
-        player = players[int(group_player["pid"])]
+        player = players[int(group_player[const.ATTR_PLAYER_ID])]
         if group_player["role"] == "leader":
             leader = player
         else:

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -174,10 +174,8 @@ class Heos:
         if event.command == const.EVENT_SOURCES_CHANGED and self._music_sources_loaded:
             await self.get_music_sources(refresh=True)
         elif event.command == const.EVENT_USER_CHANGED:
-            if const.PARAM_SIGNED_IN in event.message:
-                self._signed_in_username = event.get_message_value(
-                    const.PARAM_USER_NAME
-                )
+            if const.ATTR_SIGNED_IN in event.message:
+                self._signed_in_username = event.get_message_value(const.ATTR_USER_NAME)
             else:
                 self._signed_in_username = None
         elif event.command == const.EVENT_GROUPS_CHANGED and self._groups_loaded:
@@ -188,7 +186,7 @@ class Heos:
 
     async def _handle_player_event(self, event: HeosMessage) -> None:
         """Process an event about a player."""
-        player_id = event.get_message_value_int(const.PARAM_PLAYER_ID)
+        player_id = event.get_message_value_int(const.ATTR_PLAYER_ID)
         player = self.players.get(player_id)
         if player and (
             await player.event_update(event, self._options.all_progress_events)
@@ -198,7 +196,7 @@ class Heos:
 
     async def _handle_group_event(self, event: HeosMessage) -> None:
         """Process an event about a group."""
-        group_id = event.get_message_value_int(const.PARAM_GROUP_ID)
+        group_id = event.get_message_value_int(const.ATTR_GROUP_ID)
         group = self.groups.get(group_id)
         if group:
             await group.event_update(event)

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -240,7 +240,7 @@ class Heos:
         payload = await self._commands.get_players()
         existing = list(self._players.values())
         for player_data in payload:
-            player_id = player_data["pid"]
+            player_id = player_data[const.ATTR_PLAYER_ID]
             name = player_data[const.ATTR_NAME]
             version = player_data[const.ATTR_VERSION]
             # Try finding existing player by id or match name when firmware

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -241,8 +241,8 @@ class Heos:
         existing = list(self._players.values())
         for player_data in payload:
             player_id = player_data["pid"]
-            name = player_data["name"]
-            version = player_data["version"]
+            name = player_data[const.ATTR_NAME]
+            version = player_data[const.ATTR_VERSION]
             # Try finding existing player by id or match name when firmware
             # version is different because IDs change after a firmware upgrade
             player = next(

--- a/pyheos/message.py
+++ b/pyheos/message.py
@@ -59,7 +59,7 @@ class HeosCommand:
             value = const.MASK if mask and key in const.MASKED_PARAMS else items[key]
             item = f"{key}={HeosCommand._quote(value)}"
             # Ensure 'url' goes last per CLI spec
-            if key == const.PARAM_URL:
+            if key == const.ATTR_URL:
                 pairs.append(item)
             else:
                 pairs.insert(0, item)

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -159,12 +159,12 @@ class HeosPlayer:
         self._commands = heos._commands
 
         self._name: str = str(data[const.ATTR_NAME])
-        self._player_id: int = int(data["pid"])
+        self._player_id: int = int(data[const.ATTR_PLAYER_ID])
         self._model: str = data[const.ATTR_MODEL]
         self._version: str = data[const.ATTR_VERSION]
         self._ip_address: str = data[const.ATTR_IP_ADDRESS]
         self._network: str = data[const.ATTR_NETWORK]
-        self._line_out: int = data["lineout"]
+        self._line_out: int = data[const.ATTR_LINE_OUT]
 
         self._state: str | None = None
         self._volume: int | None = None
@@ -194,7 +194,7 @@ class HeosPlayer:
         self._version = data[const.ATTR_VERSION]
         self._ip_address = data[const.ATTR_IP_ADDRESS]
         self._network = data[const.ATTR_NETWORK]
-        self._line_out = data["lineout"]
+        self._line_out = data[const.ATTR_LINE_OUT]
 
     async def refresh(self) -> None:
         """Pull current state."""

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -158,12 +158,12 @@ class HeosPlayer:
         # pylint: disable=protected-access
         self._commands = heos._commands
 
-        self._name: str = str(data["name"])
+        self._name: str = str(data[const.ATTR_NAME])
         self._player_id: int = int(data["pid"])
-        self._model: str = data["model"]
-        self._version: str = data["version"]
-        self._ip_address: str = data["ip"]
-        self._network: str = data["network"]
+        self._model: str = data[const.ATTR_MODEL]
+        self._version: str = data[const.ATTR_VERSION]
+        self._ip_address: str = data[const.ATTR_IP_ADDRESS]
+        self._network: str = data[const.ATTR_NETWORK]
         self._line_out: int = data["lineout"]
 
         self._state: str | None = None
@@ -189,11 +189,11 @@ class HeosPlayer:
 
     def from_data(self, data: dict[str, Any]) -> None:
         """Update the attributes from the supplied data."""
-        self._name = str(data["name"])
-        self._model = data["model"]
-        self._version = data["version"]
-        self._ip_address = data["ip"]
-        self._network = data["network"]
+        self._name = str(data[const.ATTR_NAME])
+        self._model = data[const.ATTR_MODEL]
+        self._version = data[const.ATTR_VERSION]
+        self._ip_address = data[const.ATTR_IP_ADDRESS]
+        self._network = data[const.ATTR_NETWORK]
         self._line_out = data["lineout"]
 
     async def refresh(self) -> None:
@@ -336,7 +336,7 @@ class HeosPlayer:
     async def get_quick_selects(self) -> dict[int, str]:
         """Get a list of quick selects."""
         payload = await self._commands.get_quick_selects(self._player_id)
-        return {int(data["id"]): data["name"] for data in payload}
+        return {int(data["id"]): data[const.ATTR_NAME] for data in payload}
 
     async def event_update(self, event: HeosMessage, all_progress_events: bool) -> bool:
         """Return True if player update event changed state."""

--- a/pyheos/source.py
+++ b/pyheos/source.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Sequence
 
+from pyheos import const
 from pyheos.command import HeosCommands  # pylint: disable=unused-import
 
 
@@ -44,7 +45,7 @@ class HeosSource:
     def __init__(self, commands: HeosCommands, data: dict[str, Any]) -> None:
         """Init the source class."""
         self._commands = commands
-        self._name: str = data["name"]
+        self._name: str = data[const.ATTR_NAME]
         self._image_url: str = data["image_url"]
         self._type: str = data["type"]
         self._source_id: int | None = (

--- a/pyheos/system.py
+++ b/pyheos/system.py
@@ -1,0 +1,69 @@
+"""Define the System module."""
+
+from dataclasses import dataclass
+from functools import cached_property
+
+from pyheos import const
+
+
+@dataclass(frozen=True)
+class HeosHost:
+    """Represents a HEOS host.
+
+    This class is used to store information about a HEOS host and is not tracked or updated once created.
+    """
+
+    name: str
+    model: str
+    serial: str | None
+    version: str
+    ip_address: str
+    network: str
+
+    @classmethod
+    def from_data(cls, data: dict[str, str]) -> "HeosHost":
+        """Create a HeosHost object from a dictionary.
+
+        Args:
+            data (dict): The dictionary to create the HeosHost object from.
+
+        Returns:
+            HeosHost: The created HeosHost object.
+        """
+        return HeosHost(
+            data[const.ATTR_NAME],
+            data[const.ATTR_MODEL],
+            data.get(const.ATTR_SERIAL),
+            data[const.ATTR_VERSION],
+            data[const.ATTR_IP_ADDRESS],
+            data[const.ATTR_NETWORK],
+        )
+
+
+@dataclass
+class HeosSystem:
+    """Represents information about a HEOS system.
+
+    This class is used to store information about a HEOS system and is not tracked or updated once created.
+    """
+
+    signed_in_username: str | None
+    host: HeosHost
+    hosts: list[HeosHost]
+
+    @property
+    def is_signed_in(self) -> bool:
+        """Return whether the system is signed in."""
+        return self.signed_in_username is not None
+
+    @cached_property
+    def preferred_hosts(self) -> list[HeosHost]:
+        """Return the preferred hosts."""
+        return list(
+            [host for host in self.hosts if host.network == const.NETWORK_TYPE_WIRED]
+        )
+
+    @cached_property
+    def connected_to_preferred_host(self) -> bool:
+        """Return whether the system is connected to a host."""
+        return self.host in self.preferred_hosts

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -146,7 +146,7 @@ class MockHeosDevice:
                 continue
 
             if command == const.COMMAND_REGISTER_FOR_CHANGE_EVENTS:
-                enable = str(query["enable"])
+                enable = str(query[const.ATTR_ENABLE])
                 log.is_registered_for_events = enable == "on"
                 response = (await get_fixture(fixture_name)).replace("{enable}", enable)
                 writer.write((response + SEPARATOR).encode())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,7 +194,7 @@ class CommandMatcher:
     async def _get_response(self, response: str, query: dict) -> str:
         response = await get_fixture(response)
         keys = {
-            const.PARAM_PLAYER_ID: "{player_id}",
+            const.ATTR_PLAYER_ID: "{player_id}",
             "state": "{state}",
             "level": "{level}",
         }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,7 +194,7 @@ class CommandMatcher:
     async def _get_response(self, response: str, query: dict) -> str:
         response = await get_fixture(response)
         keys = {
-            "pid": "{player_id}",
+            const.PARAM_PLAYER_ID: "{player_id}",
             "state": "{state}",
             "level": "{level}",
         }

--- a/tests/fixtures/player.get_players.json
+++ b/tests/fixtures/player.get_players.json
@@ -9,16 +9,17 @@
 			"pid": 1,
 			"model": "HEOS Drive",
 			"version": "1.493.180",
-			"ip": "192.168.0.1",
+			"ip": "127.0.0.1",
 			"network": "wired",
-			"lineout": 1
+			"lineout": 1,
+			"serial": "B1A2C3K"
 		}, {
 			"name": "Front Porch",
 			"pid": 2,
 			"model": "HEOS Drive",
 			"version": "1.493.180",
-			"ip": "192.168.0.2",
-			"network": "wireless",
+			"ip": "127.0.0.2",
+			"network": "wifi",
 			"lineout": 1
 		}
 	]

--- a/tests/fixtures/player.get_players_changed.json
+++ b/tests/fixtures/player.get_players_changed.json
@@ -11,14 +11,15 @@
 			"version": "1.493.180",
 			"ip": "192.168.0.1",
 			"network": "wired",
-			"lineout": 1
+			"lineout": 1,
+			"serial": "B1A2C3K"
 		}, {
 			"name": "Basement",
 			"pid": 3,
 			"model": "HEOS Drive",
 			"version": "1.493.180",
-			"ip": "192.168.0.3",
-			"network": "wireless",
+			"ip": "127.0.0.3",
+			"network": "wifi",
 			"lineout": 1
 		}
 	]

--- a/tests/fixtures/player.get_players_firmware_update.json
+++ b/tests/fixtures/player.get_players_firmware_update.json
@@ -9,16 +9,17 @@
 			"pid": 101,
 			"model": "HEOS Drive",
 			"version": "1.500.000",
-			"ip": "192.168.0.1",
+			"ip": "127.0.0.1",
 			"network": "wired",
-			"lineout": 1
+			"lineout": 1,
+			"serial": "B1A2C3K"
 		}, {
 			"name": "Front Porch",
 			"pid": 102,
 			"model": "HEOS Drive",
 			"version": "1.500.000",
-			"ip": "192.168.0.2",
-			"network": "wireless",
+			"ip": "127.0.0.2",
+			"network": "wifi",
 			"lineout": 1
 		}
 	]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -13,7 +13,9 @@ async def test_set_volume(mock_device: MockHeosDevice, heos: Heos) -> None:
     await heos.get_groups()
     group = heos.groups[1]
     mock_device.register(
-        const.COMMAND_SET_GROUP_VOLUME, {"level": "25", "gid": "1"}, "group.set_volume"
+        const.COMMAND_SET_GROUP_VOLUME,
+        {"level": "25", const.ATTR_GROUP_ID: "1"},
+        "group.set_volume",
     )
     with pytest.raises(ValueError):
         await group.set_volume(-1)
@@ -28,7 +30,9 @@ async def test_volume_down(mock_device: MockHeosDevice, heos: Heos) -> None:
     await heos.get_groups()
     group = heos.groups[1]
     mock_device.register(
-        const.COMMAND_GROUP_VOLUME_DOWN, {"step": "6", "gid": "1"}, "group.volume_down"
+        const.COMMAND_GROUP_VOLUME_DOWN,
+        {"step": "6", const.ATTR_GROUP_ID: "1"},
+        "group.volume_down",
     )
 
     with pytest.raises(ValueError):
@@ -44,7 +48,9 @@ async def test_volume_up(mock_device: MockHeosDevice, heos: Heos) -> None:
     await heos.get_groups()
     group = heos.groups[1]
     mock_device.register(
-        const.COMMAND_GROUP_VOLUME_UP, {"step": "6", "gid": "1"}, "group.volume_up"
+        const.COMMAND_GROUP_VOLUME_UP,
+        {"step": "6", const.ATTR_GROUP_ID: "1"},
+        "group.volume_up",
     )
     with pytest.raises(ValueError):
         await group.volume_up(0)
@@ -60,13 +66,15 @@ async def test_set_mute(mock_device: MockHeosDevice, heos: Heos) -> None:
     group = heos.groups[1]
 
     mock_device.register(
-        const.COMMAND_SET_GROUP_MUTE, {"gid": "1", "state": "on"}, "group.set_mute"
+        const.COMMAND_SET_GROUP_MUTE,
+        {const.ATTR_GROUP_ID: "1", "state": "on"},
+        "group.set_mute",
     )
     await group.mute()
 
     mock_device.register(
         const.COMMAND_SET_GROUP_MUTE,
-        {"gid": "1", "state": "off"},
+        {const.ATTR_GROUP_ID: "1", "state": "off"},
         "group.set_mute",
         replace=True,
     )
@@ -79,6 +87,6 @@ async def test_toggle_mute(mock_device: MockHeosDevice, heos: Heos) -> None:
     await heos.get_groups()
     group = heos.groups[1]
     mock_device.register(
-        const.COMMAND_GROUP_TOGGLE_MUTE, {"gid": "1"}, "group.toggle_mute"
+        const.COMMAND_GROUP_TOGGLE_MUTE, {const.ATTR_GROUP_ID: "1"}, "group.toggle_mute"
     )
     await group.toggle_mute()

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -370,7 +370,7 @@ async def test_get_players(mock_device: MockHeosDevice, heos: Heos) -> None:
     assert player.ip_address == "127.0.0.1"
     assert player.line_out == 1
     assert player.model == "HEOS Drive"
-    assert player.network == "wired"
+    assert player.network == const.NETWORK_TYPE_WIRED
     assert player.state == const.PLAY_STATE_STOP
     assert player.version == "1.493.180"
     assert player.volume == 36

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -1030,7 +1030,7 @@ async def test_get_groups(mock_device: MockHeosDevice, heos: Heos) -> None:
 @pytest.mark.asyncio
 async def test_create_group(mock_device: MockHeosDevice, heos: Heos) -> None:
     """Test creating a group."""
-    data = {"pid": "1,2,3"}
+    data = {const.ATTR_PLAYER_ID: "1,2,3"}
     mock_device.register(const.COMMAND_SET_GROUP, data, "group.set_group_create")
     await heos.create_group(1, [2, 3])
 
@@ -1038,7 +1038,7 @@ async def test_create_group(mock_device: MockHeosDevice, heos: Heos) -> None:
 @pytest.mark.asyncio
 async def test_remove_group(mock_device: MockHeosDevice, heos: Heos) -> None:
     """Test removing a group."""
-    data = {"pid": "1"}
+    data = {const.ATTR_PLAYER_ID: "1"}
     mock_device.register(const.COMMAND_SET_GROUP, data, "group.set_group_remove")
     await heos.remove_group(1)
 
@@ -1046,6 +1046,6 @@ async def test_remove_group(mock_device: MockHeosDevice, heos: Heos) -> None:
 @pytest.mark.asyncio
 async def test_update_group(mock_device: MockHeosDevice, heos: Heos) -> None:
     """Test removing a group."""
-    data = {"pid": "1,2"}
+    data = {const.ATTR_PLAYER_ID: "1,2"}
     mock_device.register(const.COMMAND_SET_GROUP, data, "group.set_group_update")
     await heos.update_group(1, [2])

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -25,6 +25,32 @@ async def test_init() -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_connection(mock_device: MockHeosDevice) -> None:
+    """Test get_system_info method returns system info."""
+    system_info = await Heos.validate_connection("127.0.0.1")
+
+    assert system_info.signed_in_username == "example@example.com"
+    assert system_info.is_signed_in
+    assert system_info.host.ip_address == "127.0.0.1"
+    assert system_info.connected_to_preferred_host is True
+    assert [system_info.host] == system_info.preferred_hosts
+
+    assert system_info.hosts[0].ip_address == "127.0.0.1"
+    assert system_info.hosts[0].model == "HEOS Drive"
+    assert system_info.hosts[0].name == "Back Patio"
+    assert system_info.hosts[0].network == const.NETWORK_TYPE_WIRED
+    assert system_info.hosts[0].serial == "B1A2C3K"
+    assert system_info.hosts[0].version == "1.493.180"
+
+    assert system_info.hosts[1].ip_address == "127.0.0.2"
+    assert system_info.hosts[1].model == "HEOS Drive"
+    assert system_info.hosts[1].name == "Front Porch"
+    assert system_info.hosts[1].network == const.NETWORK_TYPE_WIFI
+    assert system_info.hosts[1].serial is None
+    assert system_info.hosts[1].version == "1.493.180"
+
+
+@pytest.mark.asyncio
 async def test_connect(mock_device: MockHeosDevice) -> None:
     """Test connect updates state and fires signal."""
     heos = Heos(HeosOptions("127.0.0.1", timeout=0.1, auto_reconnect_delay=0.1))
@@ -341,7 +367,7 @@ async def test_get_players(mock_device: MockHeosDevice, heos: Heos) -> None:
     player = heos.players[1]
     assert player.player_id == 1
     assert player.name == "Back Patio"
-    assert player.ip_address == "192.168.0.1"
+    assert player.ip_address == "127.0.0.1"
     assert player.line_out == 1
     assert player.model == "HEOS Drive"
     assert player.network == "wired"

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -87,8 +87,8 @@ async def test_connect_not_logged_in(mock_device: MockHeosDevice) -> None:
 async def test_connect_with_credentials_logs_in(mock_device: MockHeosDevice) -> None:
     """Test heos signs-in when credentials provided."""
     data = {
-        const.PARAM_USER_NAME: "example@example.com",
-        const.PARAM_PASSWORD: "example",
+        const.ATTR_USER_NAME: "example@example.com",
+        const.ATTR_PASSWORD: "example",
     }
     mock_device.register(const.COMMAND_SIGN_IN, data, "system.sign_in")
 
@@ -108,8 +108,8 @@ async def test_connect_with_bad_credentials_raises_event(
 ) -> None:
     """Test event raised when bad credentials supplied."""
     data = {
-        const.PARAM_USER_NAME: "example@example.com",
-        const.PARAM_PASSWORD: "example",
+        const.ATTR_USER_NAME: "example@example.com",
+        const.ATTR_PASSWORD: "example",
     }
     mock_device.register(const.COMMAND_SIGN_IN, data, "system.sign_in_failure")
     mock_device.register(
@@ -988,8 +988,8 @@ async def test_sign_in_and_out(
     assert heos.signed_in_username is None
 
     data = {
-        const.PARAM_USER_NAME: "example@example.com",
-        const.PARAM_PASSWORD: "example",
+        const.ATTR_USER_NAME: "example@example.com",
+        const.ATTR_PASSWORD: "example",
     }
 
     # Test sign-in failure
@@ -1009,7 +1009,7 @@ async def test_sign_in_and_out(
         "Command executed 'heos://system/sign_in?un=example@example.com&pw=********':"
         in caplog.text
     )
-    assert heos.signed_in_username == data[const.PARAM_USER_NAME]
+    assert heos.signed_in_username == data[const.ATTR_USER_NAME]
 
 
 @pytest.mark.asyncio

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -17,12 +17,12 @@ async def test_str() -> None:
     """Test the __str__ function."""
     data = {
         const.ATTR_NAME: "Back Patio",
-        "pid": 1,
+        const.ATTR_PLAYER_ID: 1,
         const.ATTR_MODEL: "HEOS Drive",
         const.ATTR_VERSION: "1.493.180",
         const.ATTR_IP_ADDRESS: "192.168.0.1",
         const.ATTR_NETWORK: const.NETWORK_TYPE_WIRED,
-        "lineout": 1,
+        const.ATTR_LINE_OUT: 1,
         const.ATTR_SERIAL: "1234567890",
     }
     player = HeosPlayer(Heos(HeosOptions("None")), data)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -42,14 +42,14 @@ async def test_set_state(mock_device: MockHeosDevice, heos: Heos) -> None:
     # Play
     mock_device.register(
         const.COMMAND_SET_PLAY_STATE,
-        {"pid": "1", "state": "play"},
+        {const.ATTR_PLAYER_ID: "1", "state": "play"},
         "player.set_play_state",
     )
     await player.play()
     # Pause
     mock_device.register(
         const.COMMAND_SET_PLAY_STATE,
-        {"pid": "1", "state": "pause"},
+        {const.ATTR_PLAYER_ID: "1", "state": "pause"},
         "player.set_play_state",
         replace=True,
     )
@@ -57,7 +57,7 @@ async def test_set_state(mock_device: MockHeosDevice, heos: Heos) -> None:
     # Stop
     mock_device.register(
         const.COMMAND_SET_PLAY_STATE,
-        {"pid": "1", "state": "stop"},
+        {const.ATTR_PLAYER_ID: "1", "state": "stop"},
         "player.set_play_state",
         replace=True,
     )
@@ -76,7 +76,9 @@ async def test_set_volume(mock_device: MockHeosDevice, heos: Heos) -> None:
         await player.set_volume(101)
 
     mock_device.register(
-        const.COMMAND_SET_VOLUME, {"pid": "1", "level": "100"}, "player.set_volume"
+        const.COMMAND_SET_VOLUME,
+        {const.ATTR_PLAYER_ID: "1", "level": "100"},
+        "player.set_volume",
     )
     await player.set_volume(100)
 
@@ -88,13 +90,15 @@ async def test_set_mute(mock_device: MockHeosDevice, heos: Heos) -> None:
     player = heos.players[1]
     # Mute
     mock_device.register(
-        const.COMMAND_SET_MUTE, {"pid": "1", "state": "on"}, "player.set_mute"
+        const.COMMAND_SET_MUTE,
+        {const.ATTR_PLAYER_ID: "1", "state": "on"},
+        "player.set_mute",
     )
     await player.mute()
     # Unmute
     mock_device.register(
         const.COMMAND_SET_MUTE,
-        {"pid": "1", "state": "off"},
+        {const.ATTR_PLAYER_ID: "1", "state": "off"},
         "player.set_mute",
         replace=True,
     )
@@ -106,7 +110,9 @@ async def test_toggle_mute(mock_device: MockHeosDevice, heos: Heos) -> None:
     """Test the toggle_mute command."""
     await heos.get_players()
     player = heos.players[1]
-    mock_device.register(const.COMMAND_TOGGLE_MUTE, {"pid": "1"}, "player.toggle_mute")
+    mock_device.register(
+        const.COMMAND_TOGGLE_MUTE, {const.ATTR_PLAYER_ID: "1"}, "player.toggle_mute"
+    )
     await player.toggle_mute()
 
 
@@ -120,7 +126,9 @@ async def test_volume_up(mock_device: MockHeosDevice, heos: Heos) -> None:
     with pytest.raises(ValueError):
         await player.volume_up(11)
     mock_device.register(
-        const.COMMAND_VOLUME_UP, {"pid": "1", "step": "6"}, "player.volume_up"
+        const.COMMAND_VOLUME_UP,
+        {const.ATTR_PLAYER_ID: "1", "step": "6"},
+        "player.volume_up",
     )
     await player.volume_up(6)
 
@@ -135,7 +143,9 @@ async def test_volume_down(mock_device: MockHeosDevice, heos: Heos) -> None:
     with pytest.raises(ValueError):
         await player.volume_down(11)
     mock_device.register(
-        const.COMMAND_VOLUME_DOWN, {"pid": "1", "step": "6"}, "player.volume_down"
+        const.COMMAND_VOLUME_DOWN,
+        {const.ATTR_PLAYER_ID: "1", "step": "6"},
+        "player.volume_down",
     )
     await player.volume_down(6)
 
@@ -145,7 +155,7 @@ async def test_set_play_mode(mock_device: MockHeosDevice, heos: Heos) -> None:
     """Test the volume commands."""
     await heos.get_players()
     player = heos.players[1]
-    args = {"pid": "1", "repeat": const.REPEAT_ON_ALL, "shuffle": "on"}
+    args = {const.ATTR_PLAYER_ID: "1", "repeat": const.REPEAT_ON_ALL, "shuffle": "on"}
     mock_device.register(const.COMMAND_SET_PLAY_MODE, args, "player.set_play_mode")
 
     await player.set_play_mode(const.REPEAT_ON_ALL, True)
@@ -159,7 +169,7 @@ async def test_play_next_previous(mock_device: MockHeosDevice, heos: Heos) -> No
     """Test the volume commands."""
     await heos.get_players()
     player = heos.players[1]
-    args = {"pid": "1"}
+    args = {const.ATTR_PLAYER_ID: "1"}
     # Next
     mock_device.register(const.COMMAND_PLAY_NEXT, args, "player.play_next")
     await player.play_next()
@@ -173,7 +183,7 @@ async def test_clear_queue(mock_device: MockHeosDevice, heos: Heos) -> None:
     """Test the volume commands."""
     await heos.get_players()
     player = heos.players[1]
-    args = {"pid": "1"}
+    args = {const.ATTR_PLAYER_ID: "1"}
     mock_device.register(const.COMMAND_CLEAR_QUEUE, args, "player.clear_queue")
     await player.clear_queue()
 
@@ -199,7 +209,7 @@ async def test_play_input_source(mock_device: MockHeosDevice, heos: Heos) -> Non
 
     input_source = InputSource(1, "AUX In 1", const.INPUT_AUX_IN_1)
     args = {
-        "pid": "1",
+        const.ATTR_PLAYER_ID: "1",
         "spid": str(input_source.player_id),
         "input": input_source.input_name,
     }
@@ -217,7 +227,7 @@ async def test_play_favorite(mock_device: MockHeosDevice, heos: Heos) -> None:
     with pytest.raises(ValueError):
         await player.play_favorite(0)
 
-    args = {"pid": "1", "preset": "1"}
+    args = {const.ATTR_PLAYER_ID: "1", "preset": "1"}
     mock_device.register(const.COMMAND_BROWSE_PLAY_PRESET, args, "browse.play_preset")
 
     await player.play_favorite(1)
@@ -229,7 +239,7 @@ async def test_play_url(mock_device: MockHeosDevice, heos: Heos) -> None:
     await heos.get_players()
     player = heos.players[1]
     url = "https://my.website.com/podcast.mp3"
-    args = {"pid": "1", "url": url}
+    args = {const.ATTR_PLAYER_ID: "1", const.ATTR_URL: url}
     mock_device.register(const.COMMAND_BROWSE_PLAY_STREAM, args, "browse.play_stream")
 
     await player.play_url(url)
@@ -246,7 +256,7 @@ async def test_play_quick_select(mock_device: MockHeosDevice, heos: Heos) -> Non
     with pytest.raises(ValueError):
         await player.play_quick_select(7)
 
-    args = {"pid": "1", "id": "2"}
+    args = {const.ATTR_PLAYER_ID: "1", "id": "2"}
     mock_device.register(
         const.COMMAND_PLAY_QUICK_SELECT, args, "player.play_quickselect"
     )
@@ -264,7 +274,7 @@ async def test_set_quick_select(mock_device: MockHeosDevice, heos: Heos) -> None
     with pytest.raises(ValueError):
         await player.set_quick_select(7)
 
-    args = {"pid": "1", "id": "2"}
+    args = {const.ATTR_PLAYER_ID: "1", "id": "2"}
     mock_device.register(const.COMMAND_SET_QUICK_SELECT, args, "player.set_quickselect")
     await player.set_quick_select(2)
 
@@ -274,7 +284,7 @@ async def test_get_quick_selects(mock_device: MockHeosDevice, heos: Heos) -> Non
     """Test the play favorite."""
     await heos.get_players()
     player = heos.players[1]
-    args = {"pid": "1"}
+    args = {const.ATTR_PLAYER_ID: "1"}
     mock_device.register(
         const.COMMAND_GET_QUICK_SELECTS, args, "player.get_quickselects"
     )
@@ -352,7 +362,7 @@ async def test_add_to_queue_container(mock_device: MockHeosDevice, heos: Heos) -
         },
     )
     args = {
-        "pid": "1",
+        const.ATTR_PLAYER_ID: "1",
         "sid": str(const.MUSIC_SOURCE_PLAYLISTS),
         "cid": "123",
         "aid": str(const.ADD_QUEUE_PLAY_NOW),
@@ -382,7 +392,7 @@ async def test_add_to_queue_track(mock_device: MockHeosDevice, heos: Heos) -> No
         },
     )
     args = {
-        "pid": "1",
+        const.ATTR_PLAYER_ID: "1",
         "sid": str(const.MUSIC_SOURCE_PLAYLISTS),
         "cid": "123",
         "aid": str(const.ADD_QUEUE_PLAY_NOW),

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -16,14 +16,14 @@ from tests import MockHeosDevice
 async def test_str() -> None:
     """Test the __str__ function."""
     data = {
-        "name": "Back Patio",
+        const.ATTR_NAME: "Back Patio",
         "pid": 1,
-        "model": "HEOS Drive",
-        "version": "1.493.180",
-        "ip": "192.168.0.1",
-        "network": "wired",
+        const.ATTR_MODEL: "HEOS Drive",
+        const.ATTR_VERSION: "1.493.180",
+        const.ATTR_IP_ADDRESS: "192.168.0.1",
+        const.ATTR_NETWORK: const.NETWORK_TYPE_WIRED,
         "lineout": 1,
-        "serial": "1234567890",
+        const.ATTR_SERIAL: "1234567890",
     }
     player = HeosPlayer(Heos(HeosOptions("None")), data)
     assert str(player) == "{Back Patio (HEOS Drive)}"
@@ -299,7 +299,7 @@ async def test_add_to_queue_unplayable_source(
     source = HeosSource(
         Mock(HeosCommands),
         {
-            "name": "Unplayable",
+            const.ATTR_NAME: "Unplayable",
             "type": const.TYPE_PLAYLIST,
             "image_url": "",
             "playable": "no",
@@ -320,7 +320,7 @@ async def test_add_to_queue_invalid_queue_option(
     source = HeosSource(
         Mock(HeosCommands),
         {
-            "name": "My Playlist",
+            const.ATTR_NAME: "My Playlist",
             "type": const.TYPE_PLAYLIST,
             "image_url": "",
             "playable": "yes",
@@ -342,7 +342,7 @@ async def test_add_to_queue_container(mock_device: MockHeosDevice, heos: Heos) -
     source = HeosSource(
         Mock(HeosCommands),
         {
-            "name": "My Playlist",
+            const.ATTR_NAME: "My Playlist",
             "type": const.TYPE_PLAYLIST,
             "image_url": "",
             "playable": "yes",
@@ -371,7 +371,7 @@ async def test_add_to_queue_track(mock_device: MockHeosDevice, heos: Heos) -> No
     source = HeosSource(
         Mock(HeosCommands),
         {
-            "name": "My Track",
+            const.ATTR_NAME: "My Track",
             "type": const.TYPE_SONG,
             "image_url": "",
             "playable": "yes",

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import Mock
 
+from pyheos import const
 from pyheos.command import HeosCommands
 from pyheos.source import HeosSource, InputSource
 
@@ -9,7 +10,7 @@ from pyheos.source import HeosSource, InputSource
 def test_source_str_repr() -> None:
     """Test the __str__ function."""
     data = {
-        "name": "AUX Input",
+        const.ATTR_NAME: "AUX Input",
         "image_url": "https://production.ws.skyegloup.com:443"
         "/media/images/service/logos/musicsource_logo_aux.png",
         "type": "heos_service",


### PR DESCRIPTION
## Description:
Adds a new function to get the HEOS system information and logic for preferred hosts. Also organized and cleaned-up constants.

**Related issue (if applicable):** fixes #<pyheos issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)