### PR TITLE
Add ability to update credentials

### DIFF
--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -101,7 +101,7 @@ class Heos:
     def __init__(self, options: HeosOptions) -> None:
         """Init a new instance of the Heos CLI API."""
         self._options = options
-        self._current_credential = options.credentials
+        self._current_credentials = options.credentials
         self._connection = AutoReconnectingConnection(
             options.host,
             timeout=options.timeout,
@@ -138,12 +138,12 @@ class Heos:
         """Handle when connected, which may occur more than once."""
         assert self._connection.state == const.STATE_CONNECTED
 
-        if self._current_credential:
+        if self._current_credentials:
             # Sign-in to the account if provided
             try:
                 self._signed_in_username = await self._commands.sign_in(
-                    self._current_credential.username,
-                    self._current_credential.password,
+                    self._current_credentials.username,
+                    self._current_credentials.password,
                 )
             except CommandError as err:
                 _LOGGER.debug(
@@ -229,7 +229,7 @@ class Heos:
         """
         self._signed_in_username = await self._commands.sign_in(username, password)
         if update_credential:
-            self._current_credential = Credentials(username, password)
+            self._current_credentials = Credentials(username, password)
 
     async def sign_out(self, *, clear_credential: bool = True) -> None:
         """
@@ -241,7 +241,7 @@ class Heos:
         await self._commands.sign_out()
         self._signed_in_username = None
         if clear_credential:
-            self._current_credential = None
+            self._current_credentials = None
 
     async def get_system_info(self) -> HeosSystem:
         """Get information about the HEOS system."""
@@ -418,6 +418,6 @@ class Heos:
         return self._signed_in_username
 
     @property
-    def current_credential(self) -> Credentials | None:
+    def current_credentials(self) -> Credentials | None:
         """Return the current credential, if any set."""
-        return self._current_credential
+        return self._current_credentials

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -231,16 +231,16 @@ class Heos:
         if update_credential:
             self._current_credentials = Credentials(username, password)
 
-    async def sign_out(self, *, clear_credential: bool = True) -> None:
+    async def sign_out(self, *, update_credential: bool = True) -> None:
         """
         Sign-out of the HEOS account on the device directly connected.
 
         Args:
-            clear_credential: Set to True to clear the stored credential, False to keep it. The default is True. If the credential is cleared, the account will not be signed in automatically upon reconnection.
+            update_credential: Set to True to clear the stored credential, False to keep it. The default is True. If the credential is cleared, the account will not be signed in automatically upon reconnection.
         """
         await self._commands.sign_out()
         self._signed_in_username = None
-        if clear_credential:
+        if update_credential:
             self._current_credentials = None
 
     async def get_system_info(self) -> HeosSystem:

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -416,3 +416,8 @@ class Heos:
     def signed_in_username(self) -> str | None:
         """Return the signed-in username."""
         return self._signed_in_username
+
+    @property
+    def current_credential(self) -> Credentials | None:
+        """Return the current credential, if any set."""
+        return self._current_credential

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -1035,7 +1035,7 @@ async def test_sign_in_and_out(
     assert heos.current_credentials.password == data[const.ATTR_PASSWORD]
 
     # Test sign-out does not clear credential
-    await heos.sign_out(clear_credential=False)
+    await heos.sign_out(update_credential=False)
     assert heos.signed_in_username is None
     assert heos.current_credentials is not None
 

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -978,6 +978,25 @@ async def test_get_playlists(mock_device: MockHeosDevice, heos: Heos) -> None:
 
 
 @pytest.mark.asyncio
+async def test_sign_in_does_not_update_credentials(
+    mock_device: MockHeosDevice, heos: Heos, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test sign-in does not update existing credentials."""
+    assert heos.current_credentials is None
+    data = {
+        const.ATTR_USER_NAME: "example@example.com",
+        const.ATTR_PASSWORD: "example",
+    }
+    # Sign-in, do not update credentials
+    mock_device.register(const.COMMAND_SIGN_IN, data, "system.sign_in", replace=True)
+    await heos.sign_in(
+        data[const.ATTR_USER_NAME], data[const.ATTR_PASSWORD], update_credential=False
+    )
+    assert heos.signed_in_username == data[const.ATTR_USER_NAME]
+    assert heos.current_credentials is None
+
+
+@pytest.mark.asyncio
 async def test_sign_in_and_out(
     mock_device: MockHeosDevice, heos: Heos, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -995,21 +1014,30 @@ async def test_sign_in_and_out(
     # Test sign-in failure
     mock_device.register(const.COMMAND_SIGN_IN, data, "system.sign_in_failure")
     with pytest.raises(CommandFailedError, match="User not found"):
-        await heos.sign_in("example@example.com", "example")
+        await heos.sign_in(data[const.ATTR_USER_NAME], data[const.ATTR_PASSWORD])
     assert (
         "Command failed 'heos://system/sign_in?un=example@example.com&pw=********':"
         in caplog.text
     )
+    assert heos.current_credentials is None
     assert heos.signed_in_username is None
 
-    # Test sign-in success
+    # Test sign-in success and credential set
     mock_device.register(const.COMMAND_SIGN_IN, data, "system.sign_in", replace=True)
-    await heos.sign_in("example@example.com", "example")
+    await heos.sign_in(data[const.ATTR_USER_NAME], data[const.ATTR_PASSWORD])
     assert (
         "Command executed 'heos://system/sign_in?un=example@example.com&pw=********':"
         in caplog.text
     )
     assert heos.signed_in_username == data[const.ATTR_USER_NAME]
+    assert heos.current_credentials is not None
+    assert heos.current_credentials.username == data[const.ATTR_USER_NAME]  # type: ignore[unreachable]
+    assert heos.current_credentials.password == data[const.ATTR_PASSWORD]
+
+    # Test sign-out does not clear credential
+    await heos.sign_out(clear_credential=False)
+    assert heos.signed_in_username is None
+    assert heos.current_credentials is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description:
Adds the ability to update the stored credentials when using the `sign_in` and `sign_out` functions of the `Heos` class:
* New optional parameter `update_credential` added to functions `Heos.sign_in` and `Heos.sign_out` with default value of `True`. When `True`, the stored credentials will be updated upon successful sign-in (replaced) or sign-out (cleared). These updated credentials will be used during reconnection, if auto-reconnect is enabled. If set to `False`, the stored credentials will remain unchanged.
* New property `Heos.current_credentials` exposes the currently stored crednetials, whether passed in through options, or updated as the result of a `sign_in` or `sign_out` call.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)