### PR TITLE
Refactor player commands

### DIFF
--- a/pyheos/__init__.py
+++ b/pyheos/__init__.py
@@ -12,7 +12,7 @@ from .media import (
     MediaItem,
     MediaMusicSource,
 )
-from .player import HeosNowPlayingMedia, HeosPlayer
+from .player import HeosNowPlayingMedia, HeosPlayer, PlayMode
 from .system import HeosHost, HeosSystem
 
 __all__ = [
@@ -33,4 +33,5 @@ __all__ = [
     "Media",
     "MediaItem",
     "MediaMusicSource",
+    "PlayMode",
 ]

--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -1,7 +1,7 @@
 """Define the HEOS command module."""
 
 from collections.abc import Sequence
-from typing import Any, Final, Optional, cast
+from typing import Final, Optional, cast
 
 from pyheos import const
 from pyheos.connection import ConnectionBase, HeosCommand
@@ -43,110 +43,6 @@ class HeosCommands:
     async def sign_out(self) -> None:
         """Sign out of the HEOS account."""
         await self._connection.command(HeosCommand(const.COMMAND_SIGN_OUT))
-
-    async def get_players(self) -> Sequence[dict]:
-        """Get players."""
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_PLAYERS)
-        )
-        return cast(Sequence[dict], response.payload)
-
-    async def get_player_state(self, player_id: int) -> str:
-        """Get the state of the player."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_PLAY_STATE, params)
-        )
-        return str(response.message.get(const.ATTR_STATE))
-
-    async def set_player_state(self, player_id: int, state: str) -> None:
-        """Set the state of the player."""
-        if state not in const.VALID_PLAY_STATES:
-            raise ValueError("Invalid play state: " + state)
-        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_STATE: state}
-        await self._connection.command(
-            HeosCommand(const.COMMAND_SET_PLAY_STATE, params)
-        )
-
-    async def get_now_playing_state(self, player_id: int) -> dict[str, Any]:
-        """Get the now playing media information."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_NOW_PLAYING_MEDIA, params)
-        )
-        assert isinstance(response.payload, dict)
-        return response.payload
-
-    async def get_volume(self, player_id: int) -> int:
-        """Get the volume of the player."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_VOLUME, params)
-        )
-        return response.get_message_value_int(const.ATTR_LEVEL)
-
-    async def set_volume(self, player_id: int, level: int) -> None:
-        """Set the volume of the player."""
-        if level < 0 or level > 100:
-            raise ValueError("'level' must be in the range 0-100")
-        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_LEVEL: level}
-        await self._connection.command(HeosCommand(const.COMMAND_SET_VOLUME, params))
-
-    async def get_mute(self, player_id: int) -> bool:
-        """Get the mute state of the player."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_MUTE, params)
-        )
-        return str(response.message.get(const.ATTR_STATE)) == const.VALUE_ON
-
-    async def set_mute(self, player_id: int, state: bool) -> None:
-        """Set the mute state of the player."""
-        params = {
-            const.ATTR_PLAYER_ID: player_id,
-            const.ATTR_STATE: const.VALUE_ON if state else const.VALUE_OFF,
-        }
-        await self._connection.command(HeosCommand(const.COMMAND_SET_MUTE, params))
-
-    async def volume_up(self, player_id: int, step: int = const.DEFAULT_STEP) -> None:
-        """Increase the volume level."""
-        if step < 1 or step > 10:
-            raise ValueError("'step' must be in the range 1-10")
-        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_STEP: step}
-        await self._connection.command(HeosCommand(const.COMMAND_VOLUME_UP, params))
-
-    async def volume_down(self, player_id: int, step: int = const.DEFAULT_STEP) -> None:
-        """Increase the volume level."""
-        if step < 1 or step > 10:
-            raise ValueError("'step' must be in the range 1-10")
-        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_STEP: step}
-        await self._connection.command(HeosCommand(const.COMMAND_VOLUME_DOWN, params))
-
-    async def toggle_mute(self, player_id: int) -> None:
-        """Toggle the mute state.."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        await self._connection.command(HeosCommand(const.COMMAND_TOGGLE_MUTE, params))
-
-    async def get_play_mode(self, player_id: int) -> tuple[const.RepeatType, bool]:
-        """Get the current play mode."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_PLAY_MODE, params)
-        )
-        repeat = const.RepeatType(response.get_message_value(const.ATTR_REPEAT))
-        shuffle = response.get_message_value(const.ATTR_SHUFFLE) == const.VALUE_ON
-        return repeat, shuffle
-
-    async def set_play_mode(
-        self, player_id: int, repeat: const.RepeatType, shuffle: bool
-    ) -> None:
-        """Set the current play mode."""
-        params = {
-            const.ATTR_PLAYER_ID: player_id,
-            const.ATTR_REPEAT: repeat,
-            const.ATTR_SHUFFLE: const.VALUE_ON if shuffle else const.VALUE_OFF,
-        }
-        await self._connection.command(HeosCommand(const.COMMAND_SET_PLAY_MODE, params))
 
     async def clear_queue(self, player_id: int) -> None:
         """Clear the queue."""

--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -44,21 +44,6 @@ class HeosCommands:
         """Sign out of the HEOS account."""
         await self._connection.command(HeosCommand(const.COMMAND_SIGN_OUT))
 
-    async def clear_queue(self, player_id: int) -> None:
-        """Clear the queue."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        await self._connection.command(HeosCommand(const.COMMAND_CLEAR_QUEUE, params))
-
-    async def play_next(self, player_id: int) -> None:
-        """Play next."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        await self._connection.command(HeosCommand(const.COMMAND_PLAY_NEXT, params))
-
-    async def play_previous(self, player_id: int) -> None:
-        """Play next."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        await self._connection.command(HeosCommand(const.COMMAND_PLAY_PREVIOUS, params))
-
     async def get_groups(self) -> Sequence[dict]:
         """Get groups."""
         response = await self._connection.command(HeosCommand(const.COMMAND_GET_GROUPS))
@@ -132,29 +117,3 @@ class HeosCommands:
         await self._connection.command(
             HeosCommand(const.COMMAND_GROUP_TOGGLE_MUTE, params)
         )
-
-    async def play_quick_select(self, player_id: int, quick_select_id: int) -> None:
-        """Play a quick select."""
-        if quick_select_id < 1 or quick_select_id > 6:
-            raise ValueError("'quick_select_id' must be in the range 1-6")
-        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_ID: quick_select_id}
-        await self._connection.command(
-            HeosCommand(const.COMMAND_PLAY_QUICK_SELECT, params)
-        )
-
-    async def set_quick_select(self, player_id: int, quick_select_id: int) -> None:
-        """Play a quick select."""
-        if quick_select_id < 1 or quick_select_id > 6:
-            raise ValueError("'quick_select_id' must be in the range 1-6")
-        params = {const.ATTR_PLAYER_ID: player_id, const.ATTR_ID: quick_select_id}
-        await self._connection.command(
-            HeosCommand(const.COMMAND_SET_QUICK_SELECT, params)
-        )
-
-    async def get_quick_selects(self, player_id: int) -> Sequence[dict]:
-        """Play a quick select."""
-        params = {const.ATTR_PLAYER_ID: player_id}
-        response = await self._connection.command(
-            HeosCommand(const.COMMAND_GET_QUICK_SELECTS, params)
-        )
-        return cast(Sequence[dict], response.payload)

--- a/pyheos/command/browse.py
+++ b/pyheos/command/browse.py
@@ -23,7 +23,7 @@ from pyheos.message import HeosCommand
 
 
 class BrowseCommands:
-    """Define handles for browsing commands."""
+    """Define functions for creating browse commands."""
 
     @staticmethod
     def browse(

--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -5,6 +5,12 @@ This module creates HEOS browse commands.
 
 Commands not currently implemented:
     4.2.2 Get Player Info
+    4.2.15 Get Queue
+    4.2.16 Play Queue Item
+    4.2.17 Remove Item(s) from Queue
+    4.2.18 Save Queue as Playlist
+    4.2.20 Move Queue
+    4.2.26 Check for Firmware Update
 
 """
 
@@ -160,4 +166,66 @@ class PlayerCommands:
                 const.ATTR_REPEAT: repeat,
                 const.ATTR_SHUFFLE: const.VALUE_ON if shuffle else const.VALUE_OFF,
             },
+        )
+
+    @staticmethod
+    def clear_queue(player_id: int) -> HeosCommand:
+        """Clear the queue.
+
+        References:
+            4.2.19 Clear Queue"""
+        return HeosCommand(const.COMMAND_CLEAR_QUEUE, {const.ATTR_PLAYER_ID: player_id})
+
+    @staticmethod
+    def play_next(player_id: int) -> HeosCommand:
+        """Play next.
+
+        References:
+            4.2.21 Play Next"""
+        return HeosCommand(const.COMMAND_PLAY_NEXT, {const.ATTR_PLAYER_ID: player_id})
+
+    @staticmethod
+    def play_previous(player_id: int) -> HeosCommand:
+        """Play next.
+
+        References:
+            4.2.22 Play Previous"""
+        return HeosCommand(
+            const.COMMAND_PLAY_PREVIOUS, {const.ATTR_PLAYER_ID: player_id}
+        )
+
+    @staticmethod
+    def set_quick_select(player_id: int, quick_select_id: int) -> HeosCommand:
+        """Play a quick select.
+
+        References:
+            4.2.23 Set QuickSelect"""
+        if quick_select_id < 1 or quick_select_id > 6:
+            raise ValueError("'quick_select_id' must be in the range 1-6")
+        return HeosCommand(
+            const.COMMAND_SET_QUICK_SELECT,
+            {const.ATTR_PLAYER_ID: player_id, const.ATTR_ID: quick_select_id},
+        )
+
+    @staticmethod
+    def play_quick_select(player_id: int, quick_select_id: int) -> HeosCommand:
+        """Play a quick select.
+
+        References:
+            4.2.24 Play QuickSelect"""
+        if quick_select_id < 1 or quick_select_id > 6:
+            raise ValueError("'quick_select_id' must be in the range 1-6")
+        return HeosCommand(
+            const.COMMAND_PLAY_QUICK_SELECT,
+            {const.ATTR_PLAYER_ID: player_id, const.ATTR_ID: quick_select_id},
+        )
+
+    @staticmethod
+    def get_quick_selects(player_id: int) -> HeosCommand:
+        """Get quick selects.
+
+        References:
+            4.2.25 Get QuickSelects"""
+        return HeosCommand(
+            const.COMMAND_GET_QUICK_SELECTS, {const.ATTR_PLAYER_ID: player_id}
         )

--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -32,7 +32,7 @@ class PlayerCommands:
         return HeosCommand(const.COMMAND_GET_PLAYERS)
 
     @staticmethod
-    def get_player_state(player_id: int) -> HeosCommand:
+    def get_play_state(player_id: int) -> HeosCommand:
         """Get the state of the player.
 
         References:
@@ -42,13 +42,11 @@ class PlayerCommands:
         )
 
     @staticmethod
-    def set_player_state(player_id: int, state: str) -> HeosCommand:
+    def set_play_state(player_id: int, state: const.PlayState) -> HeosCommand:
         """Set the state of the player.
 
         References:
             4.2.4 Set Play State"""
-        if state not in const.VALID_PLAY_STATES:
-            raise ValueError("Invalid play state: " + state)
         return HeosCommand(
             const.COMMAND_SET_PLAY_STATE,
             {const.ATTR_PLAYER_ID: player_id, const.ATTR_STATE: state},

--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -1,0 +1,163 @@
+"""
+Define the browse command module.
+
+This module creates HEOS browse commands.
+
+Commands not currently implemented:
+    4.2.2 Get Player Info
+
+"""
+
+from pyheos import const
+from pyheos.message import HeosCommand
+
+
+class PlayerCommands:
+    """Define functions for creating player commands."""
+
+    @staticmethod
+    def get_players() -> HeosCommand:
+        """
+        Get players.
+
+        References:
+            4.2.1 Get Players
+        """
+        return HeosCommand(const.COMMAND_GET_PLAYERS)
+
+    @staticmethod
+    def get_player_state(player_id: int) -> HeosCommand:
+        """Get the state of the player.
+
+        References:
+            4.2.3 Get Play State"""
+        return HeosCommand(
+            const.COMMAND_GET_PLAY_STATE, {const.ATTR_PLAYER_ID: player_id}
+        )
+
+    @staticmethod
+    def set_player_state(player_id: int, state: str) -> HeosCommand:
+        """Set the state of the player.
+
+        References:
+            4.2.4 Set Play State"""
+        if state not in const.VALID_PLAY_STATES:
+            raise ValueError("Invalid play state: " + state)
+        return HeosCommand(
+            const.COMMAND_SET_PLAY_STATE,
+            {const.ATTR_PLAYER_ID: player_id, const.ATTR_STATE: state},
+        )
+
+    @staticmethod
+    def get_now_playing_media(player_id: int) -> HeosCommand:
+        """Get the now playing media information.
+
+        References:
+            4.2.5 Get Now Playing Media"""
+        return HeosCommand(
+            const.COMMAND_GET_NOW_PLAYING_MEDIA, {const.ATTR_PLAYER_ID: player_id}
+        )
+
+    @staticmethod
+    def get_volume(player_id: int) -> HeosCommand:
+        """Get the volume level of the player.
+
+        References:
+            4.2.6 Get Volume"""
+        return HeosCommand(const.COMMAND_GET_VOLUME, {const.ATTR_PLAYER_ID: player_id})
+
+    @staticmethod
+    def set_volume(player_id: int, level: int) -> HeosCommand:
+        """Set the volume of the player.
+
+        References:
+            4.2.7 Set Volume"""
+        if level < 0 or level > 100:
+            raise ValueError("'level' must be in the range 0-100")
+        return HeosCommand(
+            const.COMMAND_SET_VOLUME,
+            {const.ATTR_PLAYER_ID: player_id, const.ATTR_LEVEL: level},
+        )
+
+    @staticmethod
+    def volume_up(player_id: int, step: int = const.DEFAULT_STEP) -> HeosCommand:
+        """Increase the volume level.
+
+        References:
+            4.2.8 Volume Up"""
+        if step < 1 or step > 10:
+            raise ValueError("'step' must be in the range 1-10")
+        return HeosCommand(
+            const.COMMAND_VOLUME_UP,
+            {const.ATTR_PLAYER_ID: player_id, const.ATTR_STEP: step},
+        )
+
+    @staticmethod
+    def volume_down(player_id: int, step: int = const.DEFAULT_STEP) -> HeosCommand:
+        """Increase the volume level.
+
+        References:
+            4.2.9 Volume Down"""
+        if step < 1 or step > 10:
+            raise ValueError("'step' must be in the range 1-10")
+        return HeosCommand(
+            const.COMMAND_VOLUME_DOWN,
+            {const.ATTR_PLAYER_ID: player_id, const.ATTR_STEP: step},
+        )
+
+    @staticmethod
+    def get_mute(player_id: int) -> HeosCommand:
+        """Get the mute state of the player.
+
+        References:
+            4.2.10 Get Mute"""
+        return HeosCommand(const.COMMAND_GET_MUTE, {const.ATTR_PLAYER_ID: player_id})
+
+    @staticmethod
+    def set_mute(player_id: int, state: bool) -> HeosCommand:
+        """Set the mute state of the player.
+
+        References:
+            4.2.11 Set Mute"""
+        return HeosCommand(
+            const.COMMAND_SET_MUTE,
+            {
+                const.ATTR_PLAYER_ID: player_id,
+                const.ATTR_STATE: const.VALUE_ON if state else const.VALUE_OFF,
+            },
+        )
+
+    @staticmethod
+    def toggle_mute(player_id: int) -> HeosCommand:
+        """Toggle the mute state.
+
+        References:
+            4.2.12 Toggle Mute"""
+        return HeosCommand(const.COMMAND_TOGGLE_MUTE, {const.ATTR_PLAYER_ID: player_id})
+
+    @staticmethod
+    def get_play_mode(player_id: int) -> HeosCommand:
+        """Get the current play mode.
+
+        References:
+            4.2.13 Get Play Mode"""
+        return HeosCommand(
+            const.COMMAND_GET_PLAY_MODE, {const.ATTR_PLAYER_ID: player_id}
+        )
+
+    @staticmethod
+    def set_play_mode(
+        player_id: int, repeat: const.RepeatType, shuffle: bool
+    ) -> HeosCommand:
+        """Set the current play mode.
+
+        References:
+            4.2.14 Set Play Mode"""
+        return HeosCommand(
+            const.COMMAND_SET_PLAY_MODE,
+            {
+                const.ATTR_PLAYER_ID: player_id,
+                const.ATTR_REPEAT: repeat,
+                const.ATTR_SHUFFLE: const.VALUE_ON if shuffle else const.VALUE_OFF,
+            },
+        )

--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -98,10 +98,13 @@ NETWORK_TYPE_UNKNOWN: Final = "unknown"
 DATA_NEW: Final = "new"
 DATA_MAPPED_IDS: Final = "mapped_ids"
 
-PLAY_STATE_PLAY: Final = "play"
-PLAY_STATE_PAUSE: Final = "pause"
-PLAY_STATE_STOP: Final = "stop"
-VALID_PLAY_STATES: Final = (PLAY_STATE_PLAY, PLAY_STATE_PAUSE, PLAY_STATE_STOP)
+
+class PlayState(StrEnum):
+    """Define the play states."""
+
+    PLAY = "play"
+    PAUSE = "pause"
+    STOP = "stop"
 
 
 class RepeatType(StrEnum):

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -387,24 +387,24 @@ class PlayerMixin(ConnectionMixin):
             const.DATA_MAPPED_IDS: mapped_player_ids,
         }
 
-    async def player_get_state(self, player_id: int) -> str:
+    async def player_get_play_state(self, player_id: int) -> const.PlayState:
         """Get the state of the player.
 
         References:
             4.2.3 Get Play State"""
         response = await self._connection.command(
-            PlayerCommands.get_player_state(player_id)
+            PlayerCommands.get_play_state(player_id)
         )
-        return response.get_message_value(const.ATTR_STATE)
+        return const.PlayState(response.get_message_value(const.ATTR_STATE))
 
-    async def player_set_state(self, player_id: int, state: str) -> None:
+    async def player_set_play_state(
+        self, player_id: int, state: const.PlayState
+    ) -> None:
         """Set the state of the player.
 
         References:
             4.2.4 Set Play State"""
-        await self._connection.command(
-            PlayerCommands.set_player_state(player_id, state)
-        )
+        await self._connection.command(PlayerCommands.set_play_state(player_id, state))
 
     async def get_now_playing_media(
         self, player_id: int, update: HeosNowPlayingMedia | None = None

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -502,6 +502,62 @@ class PlayerMixin(ConnectionMixin):
             PlayerCommands.set_play_mode(player_id, repeat, shuffle)
         )
 
+    async def player_clear_queue(self, player_id: int) -> None:
+        """Clear the queue.
+
+        References:
+            4.2.19 Clear Queue"""
+        await self._connection.command(PlayerCommands.clear_queue(player_id))
+
+    async def player_play_next(self, player_id: int) -> None:
+        """Play next.
+
+        References:
+            4.2.21 Play Next"""
+        await self._connection.command(PlayerCommands.play_next(player_id))
+
+    async def player_play_previous(self, player_id: int) -> None:
+        """Play next.
+
+        References:
+            4.2.22 Play Previous"""
+        await self._connection.command(PlayerCommands.play_previous(player_id))
+
+    async def player_set_quick_select(
+        self, player_id: int, quick_select_id: int
+    ) -> None:
+        """Play a quick select.
+
+        References:
+            4.2.23 Set QuickSelect"""
+        await self._connection.command(
+            PlayerCommands.set_quick_select(player_id, quick_select_id)
+        )
+
+    async def player_play_quick_select(
+        self, player_id: int, quick_select_id: int
+    ) -> None:
+        """Play a quick select.
+
+        References:
+            4.2.24 Play QuickSelect"""
+        await self._connection.command(
+            PlayerCommands.play_quick_select(player_id, quick_select_id)
+        )
+
+    async def get_player_quick_selects(self, player_id: int) -> dict[int, str]:
+        """Get quick selects.
+
+        References:
+            4.2.25 Get QuickSelects"""
+        result = await self._connection.command(
+            PlayerCommands.get_quick_selects(player_id)
+        )
+        return {
+            int(data[const.ATTR_ID]): data[const.ATTR_NAME]
+            for data in cast(list[dict], result.payload)
+        }
+
 
 class Heos(BrowseMixin, PlayerMixin):
     """The Heos class provides access to the CLI API."""

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -257,15 +257,15 @@ class HeosPlayer:
 
     async def clear_queue(self) -> None:
         """Clear the queue of the player."""
-        await self._commands.clear_queue(self._player_id)
+        await self.heos.player_clear_queue(self._player_id)
 
     async def play_next(self) -> None:
         """Clear the queue of the player."""
-        await self._commands.play_next(self._player_id)
+        await self.heos.player_play_next(self._player_id)
 
     async def play_previous(self) -> None:
         """Clear the queue of the player."""
-        await self._commands.play_previous(self._player_id)
+        await self.heos.player_play_previous(self._player_id)
 
     async def play_input_source(
         self, input_name: str, source_player_id: int | None = None
@@ -283,7 +283,7 @@ class HeosPlayer:
 
     async def play_quick_select(self, quick_select_id: int) -> None:
         """Play the specified quick select."""
-        await self._commands.play_quick_select(self._player_id, quick_select_id)
+        await self.heos.player_play_quick_select(self._player_id, quick_select_id)
 
     async def add_to_queue(
         self,
@@ -312,12 +312,11 @@ class HeosPlayer:
 
     async def set_quick_select(self, quick_select_id: int) -> None:
         """Set the specified quick select to the current source."""
-        await self._commands.set_quick_select(self._player_id, quick_select_id)
+        await self.heos.player_set_quick_select(self._player_id, quick_select_id)
 
     async def get_quick_selects(self) -> dict[int, str]:
         """Get a list of quick selects."""
-        payload = await self._commands.get_quick_selects(self._player_id)
-        return {int(data[const.ATTR_ID]): data[const.ATTR_NAME] for data in payload}
+        return await self.heos.get_player_quick_selects(self._player_id)
 
     async def event_update(self, event: HeosMessage, all_progress_events: bool) -> bool:
         """Return True if player update event changed state."""

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -134,8 +134,6 @@ class HeosPlayer:
     def __init__(self, heos: "Heos", data: dict[str, Any]) -> None:
         """Initialize a player with the data."""
         self._heos = heos
-        # pylint: disable=protected-access
-        self._commands = heos._commands
 
         self._name: str = str(data[const.ATTR_NAME])
         self._player_id: int = int(data[const.ATTR_PLAYER_ID])

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -143,7 +143,7 @@ class HeosPlayer:
         self._network: str = data[const.ATTR_NETWORK]
         self._line_out: int = data[const.ATTR_LINE_OUT]
 
-        self._state: str | None = None
+        self._state: const.PlayState | None = None
         self._volume: int | None = None
         self._is_muted: bool | None = None
         self._repeat: const.RepeatType = const.RepeatType.OFF
@@ -185,7 +185,7 @@ class HeosPlayer:
 
     async def refresh_state(self) -> None:
         """Refresh the now playing state."""
-        self._state = await self.heos.player_get_state(self._player_id)
+        self._state = await self.heos.player_get_play_state(self._player_id)
 
     async def refresh_now_playing_media(self) -> None:
         """Pull the latest now playing media."""
@@ -205,21 +205,21 @@ class HeosPlayer:
         self._repeat = play_mode.repeat
         self._shuffle = play_mode.shuffle
 
-    async def set_state(self, state: str) -> None:
+    async def set_state(self, state: const.PlayState) -> None:
         """Set the state of the player."""
-        await self.heos.player_set_state(self._player_id, state)
+        await self.heos.player_set_play_state(self._player_id, state)
 
     async def play(self) -> None:
         """Set the start to play."""
-        await self.set_state(const.PLAY_STATE_PLAY)
+        await self.set_state(const.PlayState.PLAY)
 
     async def pause(self) -> None:
         """Set the start to pause."""
-        await self.set_state(const.PLAY_STATE_PAUSE)
+        await self.set_state(const.PlayState.PAUSE)
 
     async def stop(self) -> None:
         """Set the start to stop."""
-        await self.set_state(const.PLAY_STATE_STOP)
+        await self.set_state(const.PlayState.STOP)
 
     async def set_volume(self, level: int) -> None:
         """Set the volume level."""
@@ -323,8 +323,8 @@ class HeosPlayer:
                 event, all_progress_events
             )
         if event.command == const.EVENT_PLAYER_STATE_CHANGED:
-            self._state = event.get_message_value(const.ATTR_STATE)
-            if self._state == const.PLAY_STATE_PLAY:
+            self._state = const.PlayState(event.get_message_value(const.ATTR_STATE))
+            if self._state == const.PlayState.PLAY:
                 self._now_playing_media.clear_progress()
         elif event.command == const.EVENT_PLAYER_NOW_PLAYING_CHANGED:
             await self.refresh_now_playing_media()

--- a/tests/fixtures/player.get_now_playing_media.json
+++ b/tests/fixtures/player.get_now_playing_media.json
@@ -1,19 +1,37 @@
 {
 	"heos": {
-		"command": "player/get_now_playing_media",
-		"result": "success",
-		"message": "pid={player_id}"
+	  "command": "player/get_now_playing_media",
+	  "result": "success",
+	  "message": "pid={player_id}"
 	},
 	"payload": {
-		"type": "song",
-		"song": "Disney Hits",
-		"album": "",
-		"artist": "",
-		"image_url": "",
-		"album_id": "",
-		"mid": "catalog/playlists/genres",
-		"qid": 1,
-		"sid": 13
+	  "type": "station",
+	  "song": "Disney (Children's) Radio",
+	  "station": "Disney (Children's) Radio",
+	  "album": "Album",
+	  "artist": "Artist",
+	  "image_url": "http://cont-5.p-cdn.us/images/public/int/6/1/1/9/050087149116_500W_500H.jpg",
+	  "album_id": "123456",
+	  "mid": "4256592506324148495",
+	  "qid": 1,
+	  "sid": 13
 	},
-	"options": []
-}
+	"options": [
+	  {
+		"play": [
+		  {
+			"id": 11,
+			"name": "Thumbs Up"
+		  },
+		  {
+			"id": 12,
+			"name": "Thumbs Down"
+		  },
+		  {
+			"id": 19,
+			"name": "Add to HEOS Favorites"
+		  }
+		]
+	  }
+	]
+  }

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -346,7 +346,7 @@ async def test_get_players(heos: Heos) -> None:
     assert player.line_out == 1
     assert player.model == "HEOS Drive"
     assert player.network == const.NETWORK_TYPE_WIRED
-    assert player.state == const.PLAY_STATE_STOP
+    assert player.state == const.PlayState.STOP
     assert player.version == "1.493.180"
     assert player.volume == 36
     assert not player.is_muted
@@ -371,7 +371,7 @@ async def test_player_state_changed_event(
     # assert not playing
     await heos.get_players()
     player = heos.players[1]
-    assert player.state == const.PLAY_STATE_STOP
+    assert player.state == const.PlayState.STOP
 
     # Attach dispatch handler
     signal = asyncio.Event()
@@ -386,14 +386,14 @@ async def test_player_state_changed_event(
     # Write event through mock device
     await mock_device.write_event(
         "event.player_state_changed",
-        {"player_id": player.player_id, "state": const.PLAY_STATE_PLAY},
+        {"player_id": player.player_id, "state": const.PlayState.PLAY},
     )
 
     # Wait until the signal
     await signal.wait()
     # Assert state changed
-    assert player.state == const.PLAY_STATE_PLAY
-    assert heos.players[2].state == const.PLAY_STATE_STOP
+    assert player.state == const.PlayState.PLAY
+    assert heos.players[2].state == const.PlayState.STOP
 
 
 @calls_player_commands()

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -405,16 +405,19 @@ async def test_player_now_playing_changed_event(
     await heos.get_players()
     player = heos.players[1]
     now_playing = player.now_playing_media
-    assert now_playing.album == ""
-    assert now_playing.type == "song"
-    assert now_playing.album_id == ""
-    assert now_playing.artist == ""
-    assert now_playing.image_url == ""
-    assert now_playing.media_id == "catalog/playlists/genres"
+    assert now_playing.type == "station"
+    assert now_playing.song == "Disney (Children's) Radio"
+    assert now_playing.station == "Disney (Children's) Radio"
+    assert now_playing.album == "Album"
+    assert now_playing.artist == "Artist"
+    assert (
+        now_playing.image_url
+        == "http://cont-5.p-cdn.us/images/public/int/6/1/1/9/050087149116_500W_500H.jpg"
+    )
+    assert now_playing.album_id == "123456"
+    assert now_playing.media_id == "4256592506324148495"
     assert now_playing.queue_id == 1
     assert now_playing.source_id == 13
-    assert now_playing.song == "Disney Hits"
-    assert now_playing.station is None
     assert now_playing.supported_controls == const.CONTROLS_ALL
 
     # Attach dispatch handler
@@ -1173,3 +1176,24 @@ async def test_remove_group(heos: Heos) -> None:
 async def test_update_group(heos: Heos) -> None:
     """Test removing a group."""
     await heos.update_group(1, [2])
+
+
+@calls_command("player.get_now_playing_media", {const.ATTR_PLAYER_ID: 1})
+async def test_get_now_playing_media(heos: Heos) -> None:
+    """Test removing a group."""
+    media = await heos.get_now_playing_media(1)
+
+    assert media.type == "station"
+    assert media.song == "Disney (Children's) Radio"
+    assert media.station == "Disney (Children's) Radio"
+    assert media.album == "Album"
+    assert media.artist == "Artist"
+    assert (
+        media.image_url
+        == "http://cont-5.p-cdn.us/images/public/int/6/1/1/9/050087149116_500W_500H.jpg"
+    )
+    assert media.album_id == "123456"
+    assert media.media_id == "4256592506324148495"
+    assert media.queue_id == 1
+    assert media.source_id == 13
+    assert media.supported_controls == const.CONTROLS_ALL

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -30,20 +30,20 @@ async def test_str() -> None:
 
 
 @pytest.mark.parametrize(
-    "state", (const.PLAY_STATE_PAUSE, const.PLAY_STATE_PLAY, const.PLAY_STATE_STOP)
+    "state", (const.PlayState.PAUSE, const.PlayState.PLAY, const.PlayState.STOP)
 )
 @calls_command(
     "player.set_play_state",
     {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: value(arg_name="state")},
 )
-async def test_set_state(player: HeosPlayer, state: str) -> None:
+async def test_set_state(player: HeosPlayer, state: const.PlayState) -> None:
     """Test the play, pause, and stop commands."""
     await player.set_state(state)
 
 
 @calls_command(
     "player.set_play_state",
-    {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: const.PLAY_STATE_PLAY},
+    {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: const.PlayState.PLAY},
 )
 async def test_set_play(player: HeosPlayer) -> None:
     """Test the pause commands."""
@@ -52,7 +52,7 @@ async def test_set_play(player: HeosPlayer) -> None:
 
 @calls_command(
     "player.set_play_state",
-    {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: const.PLAY_STATE_PAUSE},
+    {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: const.PlayState.PAUSE},
 )
 async def test_set_pause(player: HeosPlayer) -> None:
     """Test the play commands."""
@@ -61,7 +61,7 @@ async def test_set_pause(player: HeosPlayer) -> None:
 
 @calls_command(
     "player.set_play_state",
-    {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: const.PLAY_STATE_STOP},
+    {const.ATTR_PLAYER_ID: 1, const.ATTR_STATE: const.PlayState.STOP},
 )
 async def test_set_stop(player: HeosPlayer) -> None:
     """Test the stop commands."""


### PR DESCRIPTION
## Description:
Refactors player commands, following the same model as was done for browse commands.
- Change `HeosNowPlayingMedia` to a dataclass. No public members were changed.
- Add `PlayMode` for representing play mode instead of using tuple.

Adds new class: 

**Related issue (if applicable):** fixes #43 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)