### PR TITLE
Feature auth failure eventing

### DIFF
--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -102,6 +102,7 @@ class ConnectionBase:
     async def _reset(self) -> None:
         """Reset the state of the connection."""
         # Stop running tasks and clear list
+
         while self._running_tasks:
             task = self._running_tasks.pop()
             if task.cancel():

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -102,7 +102,6 @@ class ConnectionBase:
     async def _reset(self) -> None:
         """Reset the state of the connection."""
         # Stop running tasks and clear list
-
         while self._running_tasks:
             task = self._running_tasks.pop()
             if task.cancel():

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -952,7 +952,9 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
         if error.is_credential_error and error.command != COMMAND_SIGN_IN:
             self._signed_in_username = None
             _LOGGER.debug(
-                "HEOS Account credentials are no longer valid.", exc_info=error
+                "HEOS Account credentials are no longer valid: %s",
+                error.error_text,
+                exc_info=error,
             )
             self._dispatcher.send(
                 const.SIGNAL_HEOS_EVENT, const.EVENT_USER_CREDENTIALS_INVALID

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -940,7 +940,6 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
 
     async def disconnect(self) -> None:
         """Disconnect from the CLI."""
-        await self._dispatcher.wait_all(cancel=True)
         await self._connection.disconnect()
 
     async def _on_command_error(self, error: CommandFailedError) -> None:

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -6,12 +6,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Final, cast
 
+from pyheos.command import COMMAND_SIGN_IN
 from pyheos.command.browse import BrowseCommands
 from pyheos.command.group import GroupCommands
 from pyheos.command.player import PlayerCommands
 from pyheos.command.system import SystemCommands
 from pyheos.credentials import Credentials
-from pyheos.error import CommandError
+from pyheos.error import CommandError, CommandFailedError
 from pyheos.media import (
     BrowseResult,
     MediaItem,
@@ -900,6 +901,7 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
         self._connection.add_on_connected(self._on_connected)
         self._connection.add_on_disconnected(self._on_disconnected)
         self._connection.add_on_event(self._on_event)
+        self._connection.add_on_command_error(self._on_command_error)
 
         self._dispatcher = options.dispatcher or Dispatcher()
 
@@ -922,6 +924,7 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
                     self._current_credentials.password,
                 )
             except CommandError as err:
+                self._signed_in_username = None
                 _LOGGER.debug(
                     "Failed to sign-in to HEOS Account after connection: %s", err
                 )
@@ -943,6 +946,17 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
     async def disconnect(self) -> None:
         """Disconnect from the CLI."""
         await self._connection.disconnect()
+
+    async def _on_command_error(self, error: CommandFailedError) -> None:
+        """Handle when a command error occurs."""
+        if error.is_credential_error and error.command != COMMAND_SIGN_IN:
+            self._signed_in_username = None
+            _LOGGER.debug(
+                "HEOS Account credentials are no longer valid.", exc_info=error
+            )
+            self._dispatcher.send(
+                const.SIGNAL_HEOS_EVENT, const.EVENT_USER_CREDENTIALS_INVALID
+            )
 
     async def _on_disconnected(self, from_error: bool) -> None:
         """Handle when disconnected, which may occur more than once."""

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -897,16 +897,11 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
     def __init__(self, options: HeosOptions) -> None:
         """Init a new instance of the Heos CLI API."""
         super(Heos, self).__init__(options)
-
         self._connection.add_on_connected(self._on_connected)
         self._connection.add_on_disconnected(self._on_disconnected)
         self._connection.add_on_event(self._on_event)
         self._connection.add_on_command_error(self._on_command_error)
-
         self._dispatcher = options.dispatcher or Dispatcher()
-
-        self._music_sources: dict[int, MediaMusicSource] = {}
-        self._music_sources_loaded = False
 
     async def connect(self) -> None:
         """Connect to the CLI."""
@@ -945,6 +940,7 @@ class Heos(SystemMixin, BrowseMixin, GroupMixin, PlayerMixin):
 
     async def disconnect(self) -> None:
         """Disconnect from the CLI."""
+        await self._dispatcher.wait_all(cancel=True)
         await self._connection.disconnect()
 
     async def _on_command_error(self, error: CommandFailedError) -> None:

--- a/tests/fixtures/event.invalid.json
+++ b/tests/fixtures/event.invalid.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "event/invalid", "message": ""}}

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -1288,3 +1288,18 @@ async def test_reboot() -> None:
         assert heos.connection_state == const.STATE_CONNECTED
     finally:
         await heos.disconnect()
+
+
+async def test_unrecognized_event_logs(
+    mock_device: MockHeosDevice, heos: Heos, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test repeat mode changes when event received."""
+    # Write event through mock device
+    await mock_device.write_event("event.invalid")
+
+    await asyncio.sleep(
+        0.2
+    )  # Figure out a better way to wait for the log to be written
+    await heos.dispatcher.wait_all()
+
+    assert "Unrecognized event: " in caplog.text

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -115,13 +115,9 @@ async def test_connect_with_bad_credentials_dispatches_event(
     credentials = Credentials("example@example.com", "example")
     heos = Heos(HeosOptions("127.0.0.1", credentials=credentials, heart_beat=False))
 
-    signal = asyncio.Event()
-
-    async def handler(event: str) -> None:
-        assert event == const.EVENT_USER_CREDENTIALS_INVALID
-        signal.set()
-
-    heos.dispatcher.connect(const.SIGNAL_HEOS_EVENT, handler)
+    signal = connect_handler(
+        heos, const.SIGNAL_HEOS_EVENT, const.EVENT_USER_CREDENTIALS_INVALID
+    )
 
     await heos.connect()
     await signal.wait()

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -108,7 +108,7 @@ async def test_connect_with_credentials_logs_in(mock_device: MockHeosDevice) -> 
     "system.sign_in_failure",
     {const.ATTR_USER_NAME: "example@example.com", const.ATTR_PASSWORD: "example"},
 )
-async def test_connect_with_bad_credentials_raises_event(
+async def test_connect_with_bad_credentials_dispatches_event(
     mock_device: MockHeosDevice,
 ) -> None:
     """Test event raised when bad credentials supplied."""
@@ -130,6 +130,28 @@ async def test_connect_with_bad_credentials_raises_event(
     assert heos.signed_in_username is None
 
     await heos.disconnect()
+
+
+@calls_command(
+    "browse.browse_fail_user_not_logged_in",
+    {const.ATTR_SOURCE_ID: const.MUSIC_SOURCE_FAVORITES},
+    add_command_under_process=True,
+)
+async def test_command_credential_error_dispatches_event(heos: Heos) -> None:
+    """Test command error with credential error dispatches event."""
+    assert heos.is_signed_in
+    assert heos.signed_in_username is not None
+
+    signal = connect_handler(
+        heos, const.SIGNAL_HEOS_EVENT, const.EVENT_USER_CREDENTIALS_INVALID
+    )
+
+    with pytest.raises(CommandFailedError):
+        await heos.get_favorites()
+
+    await signal.wait()
+    assert not heos.is_signed_in
+    assert heos.signed_in_username is None  # type: ignore[unreachable]
 
 
 @calls_command("system.heart_beat")


### PR DESCRIPTION
## Description:
Wraps command responses and checks if they are an auth-related failure, and if so sends `EVENT_USER_CREDENTIALS_INVALID`. Modified dispatcher to track tasks and created ability to wait or cancel all.

**Related issue (if applicable):** fixes #53

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)