### PR TITLE
Add remaining Group commands

### DIFF
--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -33,6 +33,7 @@ COMMAND_GET_QUICK_SELECTS: Final = "player/get_quickselects"
 
 # Group commands
 COMMAND_GET_GROUPS: Final = "group/get_groups"
+COMMAND_GET_GROUP_INFO: Final = "group/get_group_info"
 COMMAND_SET_GROUP: Final = "group/set_group"
 COMMAND_GET_GROUP_VOLUME: Final = "group/get_volume"
 COMMAND_SET_GROUP_VOLUME: Final = "group/set_volume"

--- a/pyheos/command/group.py
+++ b/pyheos/command/group.py
@@ -2,10 +2,6 @@
 Define the group command module.
 
 This module creates HEOS group commands.
-
-Commands not currently implemented:
-    4.3.2 Get Group Info
-
 """
 
 from collections.abc import Sequence

--- a/pyheos/command/group.py
+++ b/pyheos/command/group.py
@@ -26,6 +26,16 @@ class GroupCommands:
         return HeosCommand(command.COMMAND_GET_GROUPS)
 
     @staticmethod
+    def get_group_info(group_id: int) -> HeosCommand:
+        """Get information about a group.
+
+        References:
+            4.3.2 Get Group Info"""
+        return HeosCommand(
+            command.COMMAND_GET_GROUP_INFO, {const.ATTR_GROUP_ID: group_id}
+        )
+
+    @staticmethod
     def set_group(player_ids: Sequence[int]) -> HeosCommand:
         """Create, modify, or ungroup players.
 

--- a/pyheos/group.py
+++ b/pyheos/group.py
@@ -86,7 +86,7 @@ class HeosGroup:
         """
         assert self.heos, "Heos instance not set"
         if refresh_base_info:
-            await self.heos.get_group_info(self.group_id, refresh=True)
+            await self.heos.get_group_info(group=self, refresh=True)
         else:
             await asyncio.gather(self.refresh_volume(), self.refresh_mute())
 

--- a/pyheos/group.py
+++ b/pyheos/group.py
@@ -34,21 +34,37 @@ class HeosGroup:
         """Create a new instance from the provided data."""
         player_id: int | None = None
         player_ids: list[int] = []
-        for group_player in data[const.ATTR_PLAYERS]:
-            # Find the loaded player
-            member_player_id = int(group_player[const.ATTR_PLAYER_ID])
-            if group_player[const.ATTR_ROLE] == const.VALUE_LEADER:
-                player_id = member_player_id
-            else:
-                player_ids.append(member_player_id)
-        if player_id is None:
-            raise ValueError("No leader found in group data")
+        player_id, player_ids = cls.__get_ids(data[const.ATTR_PLAYERS])
         return cls(
             name=data[const.ATTR_NAME],
             group_id=int(data[const.ATTR_GROUP_ID]),
             lead_player_id=player_id,
             member_player_ids=player_ids,
             heos=heos,
+        )
+
+    @staticmethod
+    def __get_ids(players: list[dict[str, Any]]) -> tuple[int, list[int]]:
+        """Get the leader and members from the player data."""
+        lead_player_id: int | None = None
+        member_player_ids: list[int] = []
+        for member_player in players:
+            # Find the loaded player
+            member_player_id = int(member_player[const.ATTR_PLAYER_ID])
+            if member_player[const.ATTR_ROLE] == const.VALUE_LEADER:
+                lead_player_id = member_player_id
+            else:
+                member_player_ids.append(member_player_id)
+        if lead_player_id is None:
+            raise ValueError("No leader found in group data")
+        return lead_player_id, member_player_ids
+
+    def _update_from_data(self, data: dict[str, Any]) -> None:
+        """Update the group with the provided data."""
+        self.name = data[const.ATTR_NAME]
+        self.group_id = int(data[const.ATTR_GROUP_ID])
+        self.lead_player_id, self.member_player_ids = self.__get_ids(
+            data[const.ATTR_PLAYERS]
         )
 
     async def on_event(self, event: HeosMessage) -> bool:
@@ -62,10 +78,17 @@ class HeosGroup:
         self.is_muted = event.get_message_value(const.ATTR_MUTE) == const.VALUE_ON
         return True
 
-    async def refresh(self) -> None:
-        """Pull current state."""
+    async def refresh(self, *, refresh_base_info: bool = True) -> None:
+        """Pulls the current volume and mute state of the group.
+
+        Args:
+            refresh_base_info: When True, the base information of the group, including the name and members, will also be pulled. Defaults is False.
+        """
         assert self.heos, "Heos instance not set"
-        await asyncio.gather(self.refresh_volume(), self.refresh_mute())
+        if refresh_base_info:
+            await self.heos.get_group_info(self.group_id, refresh=True)
+        else:
+            await asyncio.gather(self.refresh_volume(), self.refresh_mute())
 
     async def refresh_volume(self) -> None:
         """Pull the latest volume."""

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -761,16 +761,36 @@ class GroupMixin(PlayerMixin):
             self._groups_loaded = True
         return self._groups
 
-    async def get_group_info(self, group_id: int, refresh: bool = False) -> HeosGroup:
+    async def get_group_info(
+        self,
+        group_id: int | None = None,
+        group: HeosGroup | None = None,
+        *,
+        refresh: bool = False,
+    ) -> HeosGroup:
         """Get information about a group.
 
+        Only one of group_id or group should be provided.
+
         Args:
-            group_id: The identifier of the group to get information about.
+            group_id: The identifier of the group to get information about. Only one of group_id or group should be provided.
+            group: The HeosGroup instance to update with the latest information. Only one of group_id or group should be provided.
             refresh: Set to True to force a refresh of the group information.
 
         References:
             4.3.2 Get Group Info"""
-        group = self._groups.get(group_id)
+        if group_id is None and group is None:
+            raise ValueError("Either group_id or group must be provided")
+        if group_id is not None and group is not None:
+            raise ValueError("Only one of group_id or group should be provided")
+
+        # if only group_id provided, try getting from loaded
+        if group is None:
+            assert group_id is not None
+            group = self._groups.get(group_id)
+        else:
+            group_id = group.group_id
+
         if group is None or refresh:
             # Get the latest information
             result = await self._connection.command(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ disable = [
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
     "possibly-used-before-assignment",
+    "duplicate-code",
 
     # Handled by ruff
     # Ref: <https://github.com/astral-sh/ruff/issues/970>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,6 @@ async def group_fixture(heos: MockHeos) -> HeosGroup:
         name="Back Patio + Front Porch",
         group_id=1,
         lead_player_id=1,
-        member_player_ids=[1, 2],
+        member_player_ids=[2],
         heos=heos,
     )

--- a/tests/fixtures/group.get_group_info.json
+++ b/tests/fixtures/group.get_group_info.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "groups/get_group_info", "result": "success", "message": "gid=-263109739"}, "payload": {"name": "Zone 1 + Zone 2", "gid": -263109739, "players": [{"name": "Zone 2", "pid": 845195621, "role": "member"}, {"name": "Zone 1", "pid": -263109739, "role": "leader"}]}}

--- a/tests/fixtures/group.get_group_info.json
+++ b/tests/fixtures/group.get_group_info.json
@@ -1,1 +1,1 @@
-{"heos": {"command": "groups/get_group_info", "result": "success", "message": "gid=-263109739"}, "payload": {"name": "Zone 1 + Zone 2", "gid": -263109739, "players": [{"name": "Zone 2", "pid": 845195621, "role": "member"}, {"name": "Zone 1", "pid": -263109739, "role": "leader"}]}}
+{"heos": {"command": "group/get_group_info", "result": "success", "message": "gid=-263109739"}, "payload": {"name": "Zone 1 + Zone 2", "gid": -263109739, "players": [{"name": "Zone 2", "pid": 845195621, "role": "member"}, {"name": "Zone 1", "pid": -263109739, "role": "leader"}]}}


### PR DESCRIPTION
## Description:
Adds the ability to get an individual group or refresh it's base values.

### New

#### `Heos` class:
- Added `get_group_info` method to retrieve or refresh a specific group. If all groups are loaded, this will retrieve the cached instance, unless refresh=True.

#### `HeosGroup` class:
- Added parameter `refresh_base_info: bool = True` to `refresh` method to include updating the base information about the group (name, id, leader, members) in addition to mute and volume.


**Related issue (if applicable):** fixes #60

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)