### PR TITLE
Add Get Player Info

### DIFF
--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -12,6 +12,7 @@ COMMAND_BROWSE_ADD_TO_QUEUE: Final = "browse/add_to_queue"
 
 # Player commands
 COMMAND_GET_PLAYERS: Final = "player/get_players"
+COMMAND_GET_PLAYER_INFO: Final = "player/get_player_info"
 COMMAND_GET_PLAY_STATE: Final = "player/get_play_state"
 COMMAND_SET_PLAY_STATE: Final = "player/set_play_state"
 COMMAND_GET_NOW_PLAYING_MEDIA: Final = "player/get_now_playing_media"

--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -4,7 +4,6 @@ Define the player command module.
 This module creates HEOS player commands.
 
 Commands not currently implemented:
-    4.2.2 Get Player Info
     4.2.15 Get Queue
     4.2.16 Play Queue Item
     4.2.17 Remove Item(s) from Queue

--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -32,6 +32,16 @@ class PlayerCommands:
         return HeosCommand(command.COMMAND_GET_PLAYERS)
 
     @staticmethod
+    def get_player_info(player_id: int) -> HeosCommand:
+        """Get player information.
+
+        References:
+            4.2.2 Get Player Info"""
+        return HeosCommand(
+            command.COMMAND_GET_PLAYER_INFO, {const.ATTR_PLAYER_ID: player_id}
+        )
+
+    @staticmethod
     def get_play_state(player_id: int) -> HeosCommand:
         """Get the state of the player.
 

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -522,9 +522,9 @@ class PlayerMixin(ConnectionMixin):
         References:
             4.2.2 Get Player Info"""
         if player_id is None and player is None:
-            raise ValueError("Either palyer_id or player must be provided")
+            raise ValueError("Either player_id or player must be provided")
         if player_id is not None and player is not None:
-            raise ValueError("Only one of palyer_id or player should be provided")
+            raise ValueError("Only one of player_id or player should be provided")
 
         # if only palyer_id provided, try getting from loaded
         if player is None:

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -501,6 +501,52 @@ class PlayerMixin(ConnectionMixin):
             await self.load_players()
         return self._players
 
+    async def get_player_info(
+        self,
+        player_id: int | None = None,
+        player: HeosPlayer | None = None,
+        *,
+        refresh: bool = False,
+    ) -> HeosPlayer:
+        """Get information about a player.
+
+        Only one of player_id or player should be provided.
+
+        Args:
+            palyer_id: The identifier of the group to get information about. Only one of player_id or player should be provided.
+            player: The HeosPlayer instance to update with the latest information. Only one of player_id or player should be provided.
+            refresh: Set to True to force a refresh of the group information.
+        Returns:
+            A HeosPlayer instance containing the player information.
+
+        References:
+            4.2.2 Get Player Info"""
+        if player_id is None and player is None:
+            raise ValueError("Either palyer_id or player must be provided")
+        if player_id is not None and player is not None:
+            raise ValueError("Only one of palyer_id or player should be provided")
+
+        # if only palyer_id provided, try getting from loaded
+        if player is None:
+            assert player_id is not None
+            player = self._players.get(player_id)
+        else:
+            player_id = player.player_id
+
+        if player is None or refresh:
+            # Get the latest information
+            result = await self._connection.command(
+                PlayerCommands.get_player_info(player_id)
+            )
+
+            payload = cast(dict[str, Any], result.payload)
+            if player is None:
+                player = HeosPlayer.from_data(payload, cast("Heos", self))
+            else:
+                player._update_from_data(payload)
+            await player.refresh(refresh_base_info=False)
+        return player
+
     async def load_players(self) -> dict[str, list | dict]:
         """Refresh the players."""
         new_player_ids = []
@@ -528,7 +574,7 @@ class PlayerMixin(ConnectionMixin):
                 # Existing player matched - update
                 if player.player_id != player_id:
                     mapped_player_ids[player_id] = player.player_id
-                player.update_from_data(player_data)
+                player._update_from_data(player_data)
                 player.available = True
                 players[player_id] = player
                 existing.remove(player)
@@ -544,7 +590,11 @@ class PlayerMixin(ConnectionMixin):
 
         # Update all statuses
         await asyncio.gather(
-            *[player.refresh() for player in players.values() if player.available]
+            *[
+                player.refresh(refresh_base_info=False)
+                for player in players.values()
+                if player.available
+            ]
         )
         self._players = players
         self._players_loaded = True

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -136,7 +136,14 @@ class HeosPlayer:
     )
     now_playing_media: HeosNowPlayingMedia = field(default_factory=HeosNowPlayingMedia)
     available: bool = field(repr=False, hash=False, compare=False, default=True)
+    group_id: int | None = field(repr=False, hash=False, compare=False, default=None)
     heos: Optional["Heos"] = field(repr=False, hash=False, compare=False, default=None)
+
+    @staticmethod
+    def __get_optional_int(value: str | None) -> int | None:
+        if value is not None:
+            return int(value)
+        return None
 
     @classmethod
     def from_data(
@@ -154,6 +161,7 @@ class HeosPlayer:
             ip_address=data[const.ATTR_IP_ADDRESS],
             network=data[const.ATTR_NETWORK],
             line_out=int(data[const.ATTR_LINE_OUT]),
+            group_id=HeosPlayer.__get_optional_int(data.get(const.ATTR_GROUP_ID)),
             heos=heos,
         )
 
@@ -167,6 +175,7 @@ class HeosPlayer:
         self.ip_address = data[const.ATTR_IP_ADDRESS]
         self.network = data[const.ATTR_NETWORK]
         self.line_out = int(data[const.ATTR_LINE_OUT])
+        self.group_id = HeosPlayer.__get_optional_int(data.get(const.ATTR_GROUP_ID))
 
     async def on_event(self, event: HeosMessage, all_progress_events: bool) -> bool:
         """Updates the player based on the received HEOS event.

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -157,7 +157,7 @@ class HeosPlayer:
             heos=heos,
         )
 
-    def update_from_data(self, data: dict[str, Any]) -> None:
+    def _update_from_data(self, data: dict[str, Any]) -> None:
         """Update the attributes from the supplied data."""
         self.name = data[const.ATTR_NAME]
         self.player_id = int(data[const.ATTR_PLAYER_ID])
@@ -208,16 +208,23 @@ class HeosPlayer:
             callback_wrapper(callback, {0: lambda: self.player_id}),
         )
 
-    async def refresh(self) -> None:
-        """Pull current state."""
+    async def refresh(self, *, refresh_base_info: bool = True) -> None:
+        """Pull current state.
+
+        Args:
+            refresh_base_info: When True, the base information of the player, including the name, will also be pulled. Defaults is False.
+        """
         assert self.heos, "Heos instance not set"
-        await asyncio.gather(
-            self.refresh_state(),
-            self.refresh_now_playing_media(),
-            self.refresh_volume(),
-            self.refresh_mute(),
-            self.refresh_play_mode(),
-        )
+        if refresh_base_info:
+            await self.heos.get_player_info(player=self, refresh=True)
+        else:
+            await asyncio.gather(
+                self.refresh_state(),
+                self.refresh_now_playing_media(),
+                self.refresh_volume(),
+                self.refresh_mute(),
+                self.refresh_play_mode(),
+            )
 
     async def refresh_state(self) -> None:
         """Refresh the now playing state."""

--- a/tests/fixtures/player.get_player_info.json
+++ b/tests/fixtures/player.get_player_info.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "player/get_player_info", "result": "success", "message": "pid=-263109739"}, "payload": {"name": "Zone 1", "pid": -263109739, "gid": -263109739, "model": "HEOS Drive", "version": "3.34.620", "ip": "127.0.0.1", "network": "wired", "lineout": 1, "serial": "123456789"}}

--- a/tests/fixtures/player.get_players.json
+++ b/tests/fixtures/player.get_players.json
@@ -16,6 +16,7 @@
 		}, {
 			"name": "Front Porch",
 			"pid": 2,
+			"gid": 2,
 			"model": "HEOS Drive",
 			"version": "1.493.180",
 			"ip": "127.0.0.2",

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -14,6 +14,7 @@ from pyheos.error import CommandError, CommandFailedError, HeosError
 from pyheos.group import HeosGroup
 from pyheos.heos import Heos, HeosOptions
 from pyheos.media import MediaItem, MediaMusicSource
+from pyheos.player import HeosPlayer
 from tests.common import MediaItems
 
 from . import (
@@ -431,6 +432,70 @@ async def test_get_players(heos: Heos) -> None:
     assert not player.shuffle
     assert player.available
     assert player.heos == heos
+
+
+@calls_commands(
+    CallCommand("player.get_player_info", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_play_state", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_now_playing_media", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_volume", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_mute", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_play_mode", {const.ATTR_PLAYER_ID: -263109739}),
+)
+async def test_get_player_info_by_id(heos: Heos) -> None:
+    """Test retrieving player info by player id."""
+    player = await heos.get_player_info(-263109739)
+    assert player.name == "Zone 1"
+    assert player.player_id == -263109739
+
+
+@calls_player_commands()
+async def test_get_player_info_by_id_already_loaded(heos: Heos) -> None:
+    """Test retrieving player info by player id for already loaded player does not update."""
+    players = await heos.get_players()
+    original_player = players[1]
+
+    player = await heos.get_player_info(1)
+    assert original_player == player
+
+
+@calls_player_commands(
+    (1, 2),
+    CallCommand("player.get_player_info", {const.ATTR_PLAYER_ID: 1}),
+    CallCommand("player.get_play_state", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_now_playing_media", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_volume", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_mute", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_play_mode", {const.ATTR_PLAYER_ID: -263109739}),
+)
+async def test_get_player_info_by_id_already_loaded_refresh(heos: Heos) -> None:
+    """Test retrieving player info by player id for already loaded player updates."""
+    players = await heos.get_players()
+    original_player = players[1]
+
+    player = await heos.get_player_info(1, refresh=True)
+    assert original_player == player
+    assert player.name == "Zone 1"
+    assert player.player_id == -263109739
+
+
+@pytest.mark.parametrize(
+    ("player_id", "player", "error"),
+    [
+        (None, None, "Either player_id or player must be provided"),
+        (
+            1,
+            object(),
+            "Only one of player_id or player should be provided",
+        ),
+    ],
+)
+async def test_get_player_info_invalid_parameters_raises(
+    heos: Heos, player_id: int | None, player: HeosPlayer | None, error: str
+) -> None:
+    """Test retrieving player info with invalid parameters raises."""
+    with pytest.raises(ValueError, match=error):
+        await heos.get_player_info(player_id=player_id, player=player)
 
 
 @calls_player_commands()

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -432,6 +432,8 @@ async def test_get_players(heos: Heos) -> None:
     assert not player.shuffle
     assert player.available
     assert player.heos == heos
+    assert player.group_id is None
+    assert heos.players[2].group_id == 2
 
 
 @calls_commands(

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -7,7 +7,7 @@ import pytest
 from pyheos import const
 from pyheos.media import MediaItem
 from pyheos.player import HeosPlayer
-from tests import calls_command, value
+from tests import CallCommand, calls_command, calls_commands, value
 from tests.common import MediaItems
 
 
@@ -361,3 +361,38 @@ async def test_now_playing_media_unavailable(player: HeosPlayer) -> None:
     assert player.now_playing_media.image_url is None
     assert player.now_playing_media.album_id is None
     assert player.now_playing_media.media_id is None
+
+
+@calls_commands(
+    CallCommand("player.get_player_info", {const.ATTR_PLAYER_ID: 1}),
+    CallCommand("player.get_play_state", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_now_playing_media", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_volume", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_mute", {const.ATTR_PLAYER_ID: -263109739}),
+    CallCommand("player.get_play_mode", {const.ATTR_PLAYER_ID: -263109739}),
+)
+async def test_refresh(player: HeosPlayer) -> None:
+    """Test refresh, including base, updates the correct information."""
+    await player.refresh()
+
+    assert player.name == "Zone 1"
+    assert player.player_id == -263109739
+    assert player.model == "HEOS Drive"
+    assert player.version == "3.34.620"
+    assert player.ip_address == "127.0.0.1"
+    assert player.serial == "123456789"
+
+
+@calls_commands(
+    CallCommand("player.get_play_state", {const.ATTR_PLAYER_ID: 1}),
+    CallCommand("player.get_now_playing_media", {const.ATTR_PLAYER_ID: 1}),
+    CallCommand("player.get_volume", {const.ATTR_PLAYER_ID: 1}),
+    CallCommand("player.get_mute", {const.ATTR_PLAYER_ID: 1}),
+    CallCommand("player.get_play_mode", {const.ATTR_PLAYER_ID: 1}),
+)
+async def test_refresh_no_base_update(player: HeosPlayer) -> None:
+    """Test refresh updates the correct information."""
+    await player.refresh(refresh_base_info=False)
+
+    assert player.name == "Back Patio"
+    assert player.player_id == 1

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -47,7 +47,7 @@ async def test_update_from_data(player: HeosPlayer) -> None:
         const.ATTR_LINE_OUT: "0",
         const.ATTR_SERIAL: "0987654321",
     }
-    player.update_from_data(data)
+    player._update_from_data(data)
 
     assert player.name == "Patio"
     assert player.player_id == 2


### PR DESCRIPTION
## Description:
Implements the Get Player Info command and ability to refresh the data of a player.

### New

#### `Heos` class:
- Added `get_player_info` function to retrieve a specific player and optionally refresh and update an existing instance.

#### `HeosPlayer` class:
- Added parameter `refresh_base_info: bool = True` to `refresh` to optionally pull the latest player information, such as name.
- Added `group_id` field to represent the group reference the player is a member of, otherwise None.

**Related issue (if applicable):** link: #62

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)