### PR TITLE
Add enums for player fields

### DIFF
--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -160,6 +160,12 @@ _LOGGER: Final = logging.getLogger(__name__)
 TEnum = TypeVar("TEnum", bound=ReprEnum)
 
 
+def optional_int(value: str | None) -> int | None:
+    if value is not None:
+        return int(value)
+    return None
+
+
 def parse_enum(
     key: str, data: dict[str, Any], enum_type: type[TEnum], default: TEnum
 ) -> TEnum:

--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -1,7 +1,7 @@
 """Define the HEOS command module."""
 
 import logging
-from enum import StrEnum
+from enum import ReprEnum
 from typing import Any, Final, TypeVar
 
 REPORT_ISSUE_TEXT: Final = (
@@ -16,6 +16,7 @@ ATTR_AVAILABLE: Final = "available"
 ATTR_COMMAND: Final = "command"
 ATTR_CONTAINER: Final = "container"
 ATTR_CONTAINER_ID: Final = "cid"
+ATTR_CONTROL: Final = "control"
 ATTR_COUNT: Final = "count"
 ATTR_CURRENT_POSITION: Final = "cur_pos"
 ATTR_DESTINATION_QUEUE_ID: Final = "dqid"
@@ -156,12 +157,12 @@ COMMAND_SIGN_OUT: Final = "system/sign_out"
 
 _LOGGER: Final = logging.getLogger(__name__)
 
-TStrEnum = TypeVar("TStrEnum", bound=StrEnum)
+TEnum = TypeVar("TEnum", bound=ReprEnum)
 
 
 def parse_enum(
-    key: str, data: dict[str, Any], enum_type: type[TStrEnum], default: TStrEnum
-) -> TStrEnum:
+    key: str, data: dict[str, Any], enum_type: type[TEnum], default: TEnum
+) -> TEnum:
     """Parse an enum value from the provided data. This is a safe operation that will return the default value if the key is missing or the value is not recognized."""
     value = data.get(key)
     if value is None:

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -13,11 +13,13 @@ from pyheos.message import HeosMessage
 from pyheos.types import (
     AddCriteriaType,
     ControlType,
+    LineOutLevelType,
     MediaType,
     NetworkType,
     PlayState,
     RepeatType,
     SignalType,
+    VolumeControlType,
 )
 
 from . import command as c
@@ -183,8 +185,11 @@ class HeosPlayer:
     serial: str | None = field(repr=False, hash=False, compare=False)
     version: str = field(repr=True, hash=False, compare=False)
     ip_address: str = field(repr=True, hash=False, compare=False)
-    network: str = field(repr=False, hash=False, compare=False)
-    line_out: int = field(repr=False, hash=False, compare=False)
+    network: NetworkType = field(repr=False, hash=False, compare=False)
+    line_out: LineOutLevelType = field(repr=False, hash=False, compare=False)
+    control: VolumeControlType = field(
+        repr=False, hash=False, compare=False, default=VolumeControlType.UNKNOWN
+    )
     state: PlayState | None = field(repr=True, hash=False, compare=False, default=None)
     volume: int = field(repr=False, hash=False, compare=False, default=0)
     is_muted: bool = field(repr=False, hash=False, compare=False, default=False)
@@ -221,7 +226,12 @@ class HeosPlayer:
             version=data[c.ATTR_VERSION],
             ip_address=data[c.ATTR_IP_ADDRESS],
             network=parse_enum(c.ATTR_NETWORK, data, NetworkType, NetworkType.UNKNOWN),
-            line_out=int(data[c.ATTR_LINE_OUT]),
+            line_out=parse_enum(
+                c.ATTR_LINE_OUT, data, LineOutLevelType, LineOutLevelType.UNKNOWN
+            ),
+            control=parse_enum(
+                c.ATTR_CONTROL, data, VolumeControlType, VolumeControlType.UNKNOWN
+            ),
             group_id=HeosPlayer.__get_optional_int(data.get(c.ATTR_GROUP_ID)),
             heos=heos,
         )
@@ -237,7 +247,12 @@ class HeosPlayer:
         self.network = parse_enum(
             c.ATTR_NETWORK, data, NetworkType, NetworkType.UNKNOWN
         )
-        self.line_out = int(data[c.ATTR_LINE_OUT])
+        self.line_out = parse_enum(
+            c.ATTR_LINE_OUT, data, LineOutLevelType, LineOutLevelType.UNKNOWN
+        )
+        self.control = parse_enum(
+            c.ATTR_CONTROL, data, VolumeControlType, VolumeControlType.UNKNOWN
+        )
         self.group_id = HeosPlayer.__get_optional_int(data.get(c.ATTR_GROUP_ID))
 
     async def _on_event(self, event: HeosMessage, all_progress_events: bool) -> bool:

--- a/pyheos/system.py
+++ b/pyheos/system.py
@@ -19,7 +19,7 @@ class HeosHost:
     serial: str | None
     version: str
     ip_address: str
-    network: str
+    network: NetworkType
 
     @classmethod
     def from_data(cls, data: dict[str, str]) -> "HeosHost":
@@ -37,7 +37,7 @@ class HeosHost:
             data.get(c.ATTR_SERIAL),
             data[c.ATTR_VERSION],
             data[c.ATTR_IP_ADDRESS],
-            data[c.ATTR_NETWORK],
+            c.parse_enum(c.ATTR_NETWORK, data, NetworkType, NetworkType.UNKNOWN),
         )
 
 

--- a/pyheos/types.py
+++ b/pyheos/types.py
@@ -20,6 +20,24 @@ class ConnectionState(StrEnum):
     RECONNECTING = "reconnecting"
 
 
+class LineOutLevelType(IntEnum):
+    """Define the line out level types."""
+
+    UNKNOWN = 0
+    VARIABLE = 1
+    FIXED = 2
+
+
+class VolumeControlType(IntEnum):
+    "Define control types."
+
+    UNKNOWN = 0
+    NONE = 1
+    IR = 2
+    TRIGGER = 3
+    NETWORK = 4
+
+
 class NetworkType(StrEnum):
     """Define the network type."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from pyheos.group import HeosGroup
 from pyheos.heos import Heos, HeosOptions
 from pyheos.media import MediaItem, MediaMusicSource
 from pyheos.player import HeosPlayer
-from pyheos.types import NetworkType
+from pyheos.types import LineOutLevelType, NetworkType
 from tests.common import MediaItems, MediaMusicSources
 
 from . import MockHeos, MockHeosDevice
@@ -142,7 +142,7 @@ async def player_fixture(heos: MockHeos) -> HeosPlayer:
         version="1.493.180",
         ip_address="127.0.0.1",
         network=NetworkType.WIRED,
-        line_out=1,
+        line_out=LineOutLevelType.FIXED,
         heos=heos,
     )
 
@@ -158,7 +158,7 @@ async def player_front_porch_fixture(heos: MockHeos) -> HeosPlayer:
         version="1.493.180",
         ip_address="127.0.0.2",
         network=NetworkType.WIFI,
-        line_out=1,
+        line_out=LineOutLevelType.FIXED,
         heos=heos,
     )
 

--- a/tests/fixtures/player.get_players.json
+++ b/tests/fixtures/player.get_players.json
@@ -11,7 +11,8 @@
 			"version": "1.493.180",
 			"ip": "127.0.0.1",
 			"network": "wired",
-			"lineout": 1,
+			"lineout": 2,
+			"control": 2,
 			"serial": "B1A2C3K"
 		}, {
 			"name": "Front Porch",

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -43,12 +43,14 @@ from pyheos.player import CONTROLS_ALL, CONTROLS_FORWARD_ONLY, HeosPlayer
 from pyheos.types import (
     AddCriteriaType,
     ConnectionState,
+    LineOutLevelType,
     MediaType,
     NetworkType,
     PlayState,
     RepeatType,
     SignalHeosEvent,
     SignalType,
+    VolumeControlType,
 )
 from tests.common import MediaItems
 
@@ -493,7 +495,8 @@ async def test_get_players(heos: Heos) -> None:
     assert player.player_id == 1
     assert player.name == "Back Patio"
     assert player.ip_address == "127.0.0.1"
-    assert player.line_out == 1
+    assert player.line_out == LineOutLevelType.FIXED
+    assert player.control == VolumeControlType.IR
     assert player.model == "HEOS Drive"
     assert player.network == NetworkType.WIRED
     assert player.state == PlayState.STOP

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -8,7 +8,13 @@ from pyheos import command as c
 from pyheos.const import INPUT_AUX_IN_1, MUSIC_SOURCE_DEEZER, MUSIC_SOURCE_PLAYLISTS
 from pyheos.media import MediaItem
 from pyheos.player import HeosPlayer
-from pyheos.types import AddCriteriaType, NetworkType, PlayState, RepeatType
+from pyheos.types import (
+    AddCriteriaType,
+    LineOutLevelType,
+    NetworkType,
+    PlayState,
+    RepeatType,
+)
 from tests import CallCommand, calls_command, calls_commands, value
 from tests.common import MediaItems
 
@@ -41,7 +47,7 @@ def test_from_data(network: str | None, expected_network: NetworkType) -> None:
     assert player.version == "1.493.180"
     assert player.ip_address == "192.168.0.1"
     assert player.network == expected_network
-    assert player.line_out == 1
+    assert player.line_out == LineOutLevelType.VARIABLE
     assert player.serial == "1234567890"
 
 
@@ -65,7 +71,7 @@ async def test_update_from_data(player: HeosPlayer) -> None:
     assert player.version == "2.0.0"
     assert player.ip_address == "192.168.0.2"
     assert player.network == NetworkType.WIFI
-    assert player.line_out == 0
+    assert player.line_out == LineOutLevelType.UNKNOWN
     assert player.serial == "0987654321"
 
 


### PR DESCRIPTION
## Description:

### New

#### `HeosPlayer`
- New `control` property to indicate the volume control type when `lineout` is Fixed.
- `lineout` is now an enum of type `LineOutLevelType`

#### `types` module
- Added `LineOutLevelType` and `VolumeControlType`


**Related issue (if applicable):** closes: #72 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)