### PR TITLE
Add add_search_to_queue

### DIFF
--- a/pyheos/const.py
+++ b/pyheos/const.py
@@ -40,6 +40,9 @@ SYSTEM_ERROR_CONTENT_AUTHENTICATION_ERROR: Final = -1201
 SYSTEM_ERROR_CONTENT_AUTHORIZATION_ERROR: Final = -1232
 SYSTEM_ERROR_ACCOUNT_PARAMETERS_INVALID: Final = -1239
 
+# Search Crtieria Container IDs (keep discrete values as we do not control the list)
+SEARCHED_TRACKS: Final = "SEARCHED_TRACKS-"
+
 # Music Sources (keep discrete values as we do not control the list)
 MUSIC_SOURCE_CONNECT: Final = 0  # TIDAL Connect // possibly Spotify Connect as well (?)
 MUSIC_SOURCE_PANDORA: Final = 1

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -498,6 +498,33 @@ class BrowseMixin(ConnectionMixin):
             )
         )
 
+    async def add_search_to_queue(
+        self,
+        player_id: int,
+        source_id: int,
+        search: str,
+        criteria_container_id: str = const.SEARCHED_TRACKS,
+        add_criteria: AddCriteriaType = AddCriteriaType.PLAY_NOW,
+    ) -> None:
+        """Add searched tracks to the queue of the specified player.
+
+        References:
+            4.4.11 Add Container to Queue with Options
+
+        Args:
+            player_id: The identifier of the player to add the search results.
+            source_id: The identifier of the source to search.
+            search: The search string.
+            criteria_container_id: the criteria container id prefix.
+            add_criteria: Determines how tracks are added to the queue. The default is AddCriteriaType.PLAY_NOW.
+        """
+        await self.add_to_queue(
+            player_id=player_id,
+            source_id=source_id,
+            container_id=f"{criteria_container_id}{search}",
+            add_criteria=add_criteria,
+        )
+
     async def rename_playlist(
         self, source_id: int, container_id: str, new_name: str
     ) -> None:

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -465,7 +465,6 @@ class HeosPlayer:
 
     async def add_search_to_queue(
         self,
-        player_id: int,
         source_id: int,
         search: str,
         criteria_container_id: str = const.SEARCHED_TRACKS,
@@ -477,7 +476,6 @@ class HeosPlayer:
             4.4.11 Add Container to Queue with Options
 
         Args:
-            player_id: The identifier of the player to add the search results.
             source_id: The identifier of the source to search.
             search: The search string.
             criteria_container_id: the criteria container id prefix.
@@ -485,7 +483,7 @@ class HeosPlayer:
         """
         assert self.heos, "Heos instance not set"
         await self.heos.add_search_to_queue(
-            player_id=player_id,
+            player_id=self.player_id,
             source_id=source_id,
             search=search,
             criteria_container_id=criteria_container_id,

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -463,6 +463,35 @@ class HeosPlayer:
             self.player_id, source_id, container_id, media_id, add_criteria
         )
 
+    async def add_search_to_queue(
+        self,
+        player_id: int,
+        source_id: int,
+        search: str,
+        criteria_container_id: str = const.SEARCHED_TRACKS,
+        add_criteria: AddCriteriaType = AddCriteriaType.PLAY_NOW,
+    ) -> None:
+        """Add searched tracks to the queue of the specified player.
+
+        References:
+            4.4.11 Add Container to Queue with Options
+
+        Args:
+            player_id: The identifier of the player to add the search results.
+            source_id: The identifier of the source to search.
+            search: The search string.
+            criteria_container_id: the criteria container id prefix.
+            add_criteria: Determines how tracks are added to the queue. The default is AddCriteriaType.PLAY_NOW.
+        """
+        assert self.heos, "Heos instance not set"
+        await self.heos.add_search_to_queue(
+            player_id=player_id,
+            source_id=source_id,
+            search=search,
+            criteria_container_id=criteria_container_id,
+            add_criteria=add_criteria,
+        )
+
     async def play_media(
         self,
         media: MediaItem,

--- a/tests/fixtures/browse.add_to_queue_search.json
+++ b/tests/fixtures/browse.add_to_queue_search.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "browse/add_to_queue", "result": "success", "message": "pid={player_id}&sid=10&cid=SEARCHED_TRACKS-Tangerine Rays&aid=3"}}

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -459,7 +459,7 @@ async def test_add_to_queue(player: HeosPlayer) -> None:
 )
 async def test_add_search_to_queue(player: HeosPlayer) -> None:
     """Test adding a track to the queue."""
-    await player.add_search_to_queue(1, MUSIC_SOURCE_TIDAL, "Tangerine Rays")
+    await player.add_search_to_queue(MUSIC_SOURCE_TIDAL, "Tangerine Rays")
 
 
 @calls_command("player.get_now_playing_media_blank", {c.ATTR_PLAYER_ID: 1})

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -5,7 +5,13 @@ import re
 import pytest
 
 from pyheos import command as c
-from pyheos.const import INPUT_AUX_IN_1, MUSIC_SOURCE_DEEZER, MUSIC_SOURCE_PLAYLISTS
+from pyheos.const import (
+    INPUT_AUX_IN_1,
+    MUSIC_SOURCE_DEEZER,
+    MUSIC_SOURCE_PLAYLISTS,
+    MUSIC_SOURCE_TIDAL,
+    SEARCHED_TRACKS,
+)
 from pyheos.media import MediaItem
 from pyheos.player import HeosPlayer
 from pyheos.types import (
@@ -439,6 +445,21 @@ async def test_add_to_queue(player: HeosPlayer) -> None:
     await player.add_to_queue(
         MUSIC_SOURCE_DEEZER, "123", "456", AddCriteriaType.PLAY_NOW
     )
+
+
+@calls_command(
+    "browse.add_to_queue_search",
+    {
+        c.ATTR_PLAYER_ID: 1,
+        c.ATTR_SOURCE_ID: MUSIC_SOURCE_TIDAL,
+        c.ATTR_CONTAINER_ID: SEARCHED_TRACKS + "Tangerine Rays",
+        c.ATTR_ADD_CRITERIA_ID: AddCriteriaType.PLAY_NOW,
+    },
+    add_command_under_process=True,
+)
+async def test_add_search_to_queue(player: HeosPlayer) -> None:
+    """Test adding a track to the queue."""
+    await player.add_search_to_queue(1, MUSIC_SOURCE_TIDAL, "Tangerine Rays")
 
 
 @calls_command("player.get_now_playing_media_blank", {c.ATTR_PLAYER_ID: 1})


### PR DESCRIPTION
## Description:
Adds helper function for adding searched content to the queue. Currently HEOS only supports tracks.

### New

#### `Heos` class
- Added `add_search_to_queue` to add items to the queue for the specified player based on the search string.

#### `HeosPlayer` class
- Added `add_search_to_queue` to add items to the queue for the current player based on the search string.

**Related issue (if applicable):** closes #79 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)