### PR TITLE
Refresh players after group event

### DIFF
--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -46,7 +46,6 @@ class PlayerCommands(ConnectionMixin):
 
         References:
             4.2.1 Get Players"""
-        # get players and pull initial state
         if not self._players_loaded or refresh:
             await self.load_players()
         return self._players

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -234,6 +234,8 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
             else:
                 self._signed_in_username = None
         elif event.command == const.EVENT_GROUPS_CHANGED and self._groups_loaded:
+            if self._players_loaded:
+                await self.get_players(refresh=True)
             await self.get_groups(refresh=True)
 
         await self._dispatcher.wait_send(

--- a/tests/fixtures/player.get_players_no_groups.json
+++ b/tests/fixtures/player.get_players_no_groups.json
@@ -7,7 +7,6 @@
 	"payload": [{
 			"name": "Back Patio",
 			"pid": 1,
-			"gid": 2,
 			"model": "HEOS Drive",
 			"version": "1.493.180",
 			"ip": "127.0.0.1",
@@ -18,7 +17,6 @@
 		}, {
 			"name": "Front Porch",
 			"pid": 2,
-			"gid": 2,
 			"model": "HEOS Drive",
 			"version": "1.493.180",
 			"ip": "127.0.0.2",

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -493,6 +493,7 @@ async def test_get_players(heos: Heos) -> None:
     assert len(heos.players) == 2
     player = heos.players[1]
     assert player.player_id == 1
+    assert player.group_id == 2
     assert player.name == "Back Patio"
     assert player.ip_address == "127.0.0.1"
     assert player.line_out == LineOutLevelType.FIXED
@@ -507,8 +508,6 @@ async def test_get_players(heos: Heos) -> None:
     assert not player.shuffle
     assert player.available
     assert player.heos == heos
-    assert player.group_id is None
-    assert heos.players[2].group_id == 2
 
 
 @calls_commands(


### PR DESCRIPTION
## Description:
Ensures that players are refreshed after groups change so that `group_id` and any other attributes are updated (only if players have been loaded.)

**Related issue (if applicable):** fixes #86

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)