### PR TITLE
Use enum for HeosNowPlayingMedia.type

### DIFF
--- a/pyheos/command/__init__.py
+++ b/pyheos/command/__init__.py
@@ -166,22 +166,31 @@ def optional_int(value: str | None) -> int | None:
     return None
 
 
-def parse_enum(
-    key: str, data: dict[str, Any], enum_type: type[TEnum], default: TEnum
-) -> TEnum:
-    """Parse an enum value from the provided data. This is a safe operation that will return the default value if the key is missing or the value is not recognized."""
+def parse_optional_enum(
+    key: str, data: dict[str, Any], enum_type: type[TEnum]
+) -> TEnum | None:
+    """Parse an enum value from the provided data. This is a safe operation that will return None if the key is missing or the value is not recognized."""
     value = data.get(key)
     if value is None:
-        return default
+        return None
     try:
         return enum_type(value)
     except ValueError:
         _LOGGER.warning(
-            "Unrecognized '%s' value: '%s', using default value: '%s'. Full data: %s. %s",
+            "Unrecognized '%s' value: '%s'. Full data: %s. %s",
             key,
             value,
-            default,
             data,
             REPORT_ISSUE_TEXT,
         )
+        return None
+
+
+def parse_enum(
+    key: str, data: dict[str, Any], enum_type: type[TEnum], default: TEnum
+) -> TEnum:
+    """Parse an enum value from the provided data. This is a safe operation that will return the default value if the key is missing or the value is not recognized."""
+    value = parse_optional_enum(key, data, enum_type)
+    if value is None:
         return default
+    return value

--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, Optional, cast
 
 from pyheos.abc import RemoveHeosFieldABC
-from pyheos.command import optional_int, parse_enum
+from pyheos.command import optional_int, parse_enum, parse_optional_enum
 from pyheos.dispatch import DisconnectType, EventCallbackType, callback_wrapper
 from pyheos.media import MediaItem, QueueItem, ServiceOption
 from pyheos.message import HeosMessage
@@ -101,7 +101,7 @@ class PlayerUpdateResult:
 class HeosNowPlayingMedia:
     """Define now playing media information."""
 
-    type: str | None = None
+    type: MediaType | None = None
     song: str | None = None
     station: str | None = None
     album: str | None = None
@@ -128,7 +128,7 @@ class HeosNowPlayingMedia:
     def _update_from_message(self, message: HeosMessage) -> None:
         """Update the current instance from another instance."""
         data = cast(dict[str, Any], message.payload)
-        self.type = data.get(c.ATTR_TYPE)
+        self.type = parse_optional_enum(c.ATTR_TYPE, data, MediaType)
         self.song = data.get(c.ATTR_SONG)
         self.station = data.get(c.ATTR_STATION)
         self.album = data.get(c.ATTR_ALBUM)

--- a/tests/snapshots/test_heos.ambr
+++ b/tests/snapshots/test_heos.ambr
@@ -730,7 +730,7 @@
       <ControlType.PLAY_NEXT: 'play_next'>,
       <ControlType.PLAY_PREVIOUS: 'play_previous'>,
     ]),
-    'type': 'station',
+    'type': <MediaType.STATION: 'station'>,
   })
 # ---
 # name: test_get_players
@@ -782,7 +782,7 @@
           <ControlType.PLAY_NEXT: 'play_next'>,
           <ControlType.PLAY_PREVIOUS: 'play_previous'>,
         ]),
-        'type': 'station',
+        'type': <MediaType.STATION: 'station'>,
       }),
       'playback_error': None,
       'player_id': 1,
@@ -840,7 +840,7 @@
           <ControlType.PLAY_NEXT: 'play_next'>,
           <ControlType.PLAY_PREVIOUS: 'play_previous'>,
         ]),
-        'type': 'station',
+        'type': <MediaType.STATION: 'station'>,
       }),
       'playback_error': None,
       'player_id': 2,
@@ -907,7 +907,7 @@
       <ControlType.STOP: 'stop'>,
       <ControlType.PLAY_NEXT: 'play_next'>,
     ]),
-    'type': 'station',
+    'type': <MediaType.STATION: 'station'>,
   })
 # ---
 # name: test_player_now_playing_changed_event[current_state]
@@ -948,7 +948,7 @@
       <ControlType.PLAY_NEXT: 'play_next'>,
       <ControlType.PLAY_PREVIOUS: 'play_previous'>,
     ]),
-    'type': 'station',
+    'type': <MediaType.STATION: 'station'>,
   })
 # ---
 # name: test_validate_connection

--- a/tests/snapshots/test_player.ambr
+++ b/tests/snapshots/test_player.ambr
@@ -404,7 +404,7 @@
         <ControlType.PLAY_NEXT: 'play_next'>,
         <ControlType.PLAY_PREVIOUS: 'play_previous'>,
       ]),
-      'type': 'station',
+      'type': <MediaType.STATION: 'station'>,
     }),
     'playback_error': None,
     'player_id': -263109739,


### PR DESCRIPTION
## Description:
Updates the `HeosNowPlayingMedia` class so that `type` is of type `MediaType` instead of a string.

**Related issue (if applicable):** fixes #<pyheos issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)