### PR TITLE
Minor improvements to Connection

### DIFF
--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -380,11 +380,17 @@ async def test_reconnect_during_event(mock_device: MockHeosDevice) -> None:
 
     # Assert reconnects once server is back up and fires connected
     # Force reconnect timeout
-    await asyncio.sleep(0.5)  # type: ignore[unreachable]
+    reconnect_task = next(  # type: ignore[unreachable]
+        task
+        for task in heos._connection._running_tasks
+        if task.get_name() == "Reconnect"
+    )
+    await asyncio.sleep(0.5)
     await mock_device.start()
     await connect_signal.wait()
     assert heos.connection_state == ConnectionState.CONNECTED
 
+    await reconnect_task  # Ensures task completes, otherwise disconnect cancels it
     await heos.disconnect()
 
 


### PR DESCRIPTION
## Description:
Makes some minor improvements to the connection logic:
- Names tasks 
- Uses `suppress` instead of `try/except/pass`
- Removes unnecessary catching of derived exceptions (e.g. `ConnectionError` is derived from `OSError` which we were also catching)
- Modified test to wait out reconnect task
- Test coverage is now 100% 

**Related issue (if applicable):** fixes #<pyheos issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X ] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)