### PR TITLE
Fix handling of command timeouts

### DIFF
--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -137,11 +137,11 @@ class ConnectionBase:
                 return
             else:
                 self._last_activity = datetime.now()
-                await self._handle_message(
+                self._handle_message(
                     HeosMessage._from_raw_message(binary_result.decode())
                 )
 
-    async def _handle_message(self, message: HeosMessage) -> None:
+    def _handle_message(self, message: HeosMessage) -> None:
         """Handle a message received from the HEOS device."""
         if message.is_under_process:
             _LOGGER.debug("Command under process '%s'", message.command)
@@ -152,7 +152,10 @@ class ConnectionBase:
             return
 
         # Set the message on the pending command.
-        self._pending_command_event.set(message)
+        if not self._pending_command_event.set(message):
+            _LOGGER.debug(
+                "Unexpected response received: '%s': '%s'", message.command, message
+            )
 
     async def command(self, command: HeosCommand) -> HeosMessage:
         """Send a command to the HEOS device."""
@@ -165,18 +168,18 @@ class ConnectionBase:
                 raise CommandError(command.command, "Not connected to device")
             if TYPE_CHECKING:
                 assert self._writer is not None
-            assert not self._pending_command_event.is_set()
+
             # Send the command
             try:
                 self._writer.write((command.uri + SEPARATOR).encode())
                 await self._writer.drain()
             except (ConnectionError, OSError, AttributeError) as error:
                 # Occurs when the connection is broken. Run in the background to ensure connection is reset.
-                self._register_task(
-                    self._disconnect_from_error(error), "Disconnect From Error"
-                )
                 _LOGGER.debug(
                     "Command failed '%s': %s: %s", command, type(error).__name__, error
+                )
+                self._register_task(
+                    self._disconnect_from_error(error), "Disconnect From Error"
                 )
                 raise CommandError(
                     command.command, f"Command failed: {error}"
@@ -192,7 +195,7 @@ class ConnectionBase:
             # Wait for the response with a timeout
             try:
                 response = await asyncio.wait_for(
-                    self._pending_command_event.wait(), self._timeout
+                    self._pending_command_event.wait(command.command), self._timeout
                 )
             except asyncio.TimeoutError as error:
                 # Occurs when the command times out
@@ -200,9 +203,6 @@ class ConnectionBase:
                 raise CommandError(command.command, "Command timed out") from error
             finally:
                 self._pending_command_event.clear()
-
-            # The retrieved response should match the command
-            assert command.command == response.command
 
             # Check the result
             if not response.result:
@@ -340,24 +340,27 @@ class ResponseEvent:
         """Init a new instance of the CommandEvent."""
         self._event: asyncio.Event = asyncio.Event()
         self._response: HeosMessage | None = None
+        self._target_command: str | None = None
 
-    async def wait(self) -> HeosMessage:
+    async def wait(self, target_command: str) -> HeosMessage:
         """Wait until the event is set."""
+        self._target_command = target_command
         await self._event.wait()
         if TYPE_CHECKING:
             assert self._response is not None
         return self._response
 
-    def set(self, response: HeosMessage) -> None:
+    def set(self, response: HeosMessage) -> bool:
         """Set the response."""
+        if self._target_command is None or self._target_command != response.command:
+            return False
+        self._target_command = None
         self._response = response
         self._event.set()
+        return True
 
     def clear(self) -> None:
         """Clear the event."""
         self._response = None
+        self._target_command = None
         self._event.clear()
-
-    def is_set(self) -> bool:
-        """Return True if the event is set."""
-        return self._event.is_set()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -274,7 +274,7 @@ class MockHeosDevice:
         self._started: bool = False
         self.connections: list[ConnectionLog] = []
         self._matchers: list[CommandMatcher] = []
-        self._modifiers: list[CommandModifier] = []
+        self.modifiers: list[CommandModifier] = []
 
     async def start(self) -> None:
         """Start the heos server."""
@@ -364,9 +364,9 @@ class MockHeosDevice:
         modifier = CommandModifier(
             command, replay_response=replay_response, delay_response=delay_response
         )
-        self._modifiers.append(modifier)
+        self.modifiers.append(modifier)
         yield
-        self._modifiers.remove(modifier)
+        self.modifiers.remove(modifier)
 
     async def _handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -405,7 +405,7 @@ class MockHeosDevice:
                 modifier = next(
                     (
                         modifier
-                        for modifier in self._modifiers
+                        for modifier in self.modifiers
                         if modifier.command == command
                     ),
                     DEFAULT_MODIFIER,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,9 @@
 import asyncio
 import functools
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, cast
 from urllib.parse import parse_qsl, quote_plus, urlencode, urlparse
@@ -273,6 +274,7 @@ class MockHeosDevice:
         self._started: bool = False
         self.connections: list[ConnectionLog] = []
         self._matchers: list[CommandMatcher] = []
+        self._modifiers: list[CommandModifier] = []
 
     async def start(self) -> None:
         """Start the heos server."""
@@ -354,6 +356,18 @@ class MockHeosDevice:
             f"Command was not registered: {target_command} with args {target_args}."
         )
 
+    @contextmanager
+    def modify(
+        self, command: str, *, replay_response: int = 1, delay_response: float = 0.0
+    ) -> Generator[None]:
+        """Modifies behavior of command processing."""
+        modifier = CommandModifier(
+            command, replay_response=replay_response, delay_response=delay_response
+        )
+        self._modifiers.append(modifier)
+        yield
+        self._modifiers.remove(modifier)
+
     async def _handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
@@ -387,10 +401,27 @@ class MockHeosDevice:
                 None,
             )
             if matcher:
+                # Apply modifiers
+                modifier = next(
+                    (
+                        modifier
+                        for modifier in self._modifiers
+                        if modifier.command == command
+                    ),
+                    DEFAULT_MODIFIER,
+                )
+
+                # Delay the response if set
+                if modifier.delay_response > 0:
+                    await asyncio.sleep(modifier.delay_response)
+
                 responses = await matcher.get_response(query)
-                for response in responses:
-                    writer.write((response + SEPARATOR).encode())
-                    await writer.drain()
+                # Write the response multiple times if set
+                for _ in range(modifier.replay_response):
+                    for response in responses:
+                        writer.write((response + SEPARATOR).encode())
+                        await writer.drain()
+
                 continue
 
             # Special processing for known/unknown commands
@@ -512,3 +543,15 @@ class ConnectionLog:
         data = (payload + SEPARATOR).encode()
         self._writer.write(data)
         await self._writer.drain()
+
+
+@dataclass
+class CommandModifier:
+    """Define a command modifier."""
+
+    command: str
+    replay_response: int = field(kw_only=True, default=1)
+    delay_response: float = field(kw_only=True, default=0.0)
+
+
+DEFAULT_MODIFIER = CommandModifier(c.COMMAND_GET_PLAYERS)

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -344,7 +344,7 @@ async def test_event_received_during_command(mock_device: MockHeosDevice) -> Non
     """Test event received during command execution."""
     heos = await Heos.create_and_connect("127.0.0.1", heart_beat=False)
 
-    mock_device._modifiers.append(
+    mock_device.modifiers.append(
         CommandModifier(c.COMMAND_HEART_BEAT, delay_response=0.2)
     )
     command_task = asyncio.create_task(heos.heart_beat())


### PR DESCRIPTION
## Description:
Fixes inability to recover when a command response is received after the timeout period and the original caller has timed out and is no longer waiting for the response. Also improves handling/tracking of incoming responses so that if unexpected responses are received, they are logged and ignored. 

**Related issue (if applicable):** fixes #98

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)