### PR TITLE
Ensure uncaught errors in connection tasks are logged

### DIFF
--- a/tests/fixtures/player.get_now_playing_media_failed.json
+++ b/tests/fixtures/player.get_now_playing_media_failed.json
@@ -1,0 +1,1 @@
+{"heos": {"command": "player/get_now_playing_media", "result": "fail", "message": "eid=2&text=ID Not Valid&pid=1"}}


### PR DESCRIPTION
## Description:
Adds a task done callback to ensure that uncaught errors in callbacks are logged.
 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)