### PR TITLE
Ensure players and groups refresh after reconnect

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -304,6 +304,12 @@ class MockHeosDevice:
         # Wait for server to close
         await self._server.wait_closed()
 
+    async def restart(self) -> None:
+        """Restart the heos server."""
+        await self.stop()
+        await asyncio.sleep(0.1)
+        await self.start()
+
     async def write_event(
         self, fixture: str, replacements: dict[str, Any] | None = None
     ) -> None:
@@ -428,9 +434,7 @@ class MockHeosDevice:
             # Special processing for known/unknown commands
             if command == c.COMMAND_REBOOT:
                 # Simulate a reboot by shutting down the server
-                await self.stop()
-                await asyncio.sleep(0.3)
-                await self.start()
+                await self.restart()
                 return
             if command == c.COMMAND_REGISTER_FOR_CHANGE_EVENTS:
                 enable = str(query[c.ATTR_ENABLE])


### PR DESCRIPTION
## Description:
After reconnecting, this ensures that both players and groups are refreshed; the player update result is sent via event signal, and all signals that arise during reconnection are sent at the end, to ensure all data is updated and present when consumers begin reacting against the updated data.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [ ] `README.MD` updated (if necessary)