### PR TITLE
Ensure players refreshed after group event

### DIFF
--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -150,6 +150,16 @@ class PlayerCommands(ConnectionMixin):
         self._players_loaded = True
         return result
 
+    async def _refresh_players_base_info(self) -> None:
+        """Refresh the attributes of all player's base information."""
+        response = await self._connection.command(HeosCommand(c.COMMAND_GET_PLAYERS))
+        payload = cast(Sequence[dict[str, str]], response.payload)
+        for player_data in payload:
+            player_id = int(player_data[c.ATTR_PLAYER_ID])
+            player = self._players.get(player_id)
+            if player:
+                player._update_from_data(player_data)
+
     async def player_get_play_state(self, player_id: int) -> PlayState:
         """Get the state of the player.
 


### PR DESCRIPTION
## Description:
This ensures that player base attributes are updated on a groups changed event even when groups are not loaded. This ensures that `HeosPlayer.group_id` is updated and does not become stale. Optimizes the player update so it does not do a full deep refresh, and instead only does the top level.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [ ] `README.MD` updated (if necessary)