### PR TITLE
Add media URI serialization utilities

### DIFF
--- a/pyheos/util/__init__.py
+++ b/pyheos/util/__init__.py
@@ -1,0 +1,3 @@
+"""Define the utility module.
+
+These are features and functions that are not directly related to the HEOS CLI protocol specification."""

--- a/pyheos/util/mediauri.py
+++ b/pyheos/util/mediauri.py
@@ -1,0 +1,100 @@
+"""Define the mediauri module."""
+
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse
+
+from pyheos.media import MediaItem, MediaMusicSource
+from pyheos.types import MediaType
+
+BASE_URI = "heos://media"
+
+
+def is_media_uri(uri: str) -> bool:
+    """Check if the provided URI is a valid HEOS media URI.
+
+    Args:
+        uri: The URI string to check.
+    Returns:
+        True if the URI is a valid HEOS media URI, False otherwise.
+    """
+    return uri.startswith(BASE_URI)
+
+
+def to_media_uri(media: MediaItem | MediaMusicSource) -> str:
+    """Get URI string that can uniquely identify the media item.
+
+    Args:
+        media: The item to get the URI for.
+    Returns:
+        A URI string that uniquely identifies this media item in the format:
+        heos://media/<souce_id>/<type>?fields=values
+
+    """
+    base_uri = f"{BASE_URI}/{media.source_id}/{media.type}"
+    params: dict[str, Any] = {
+        "name": media.name,
+        "image_url": media.image_url,
+    }
+    if isinstance(media, MediaItem):
+        params["playable"] = media.playable
+        params["browsable"] = media.browsable
+        if media.container_id:
+            params["container_id"] = media.container_id
+        if media.media_id:
+            params["media_id"] = media.media_id
+        if media.artist:
+            params["artist"] = media.artist
+        if media.album:
+            params["album"] = media.album
+        if media.album_id:
+            params["album_id"] = media.album_id
+    else:
+        params["available"] = media.available
+        if media.service_username:
+            params["service_username"] = media.service_username
+
+    return f"{base_uri}?{urlencode(params)}"
+
+
+def from_media_uri(uri: str) -> MediaItem | MediaMusicSource:
+    """Create a new instance from the provided URI.
+
+    Args:
+        uri: The URI string to parse.
+    Returns:
+        A new MediaMusicSource instance representing the URI string.
+    Raises:
+        ValueError: If the URI is not a valid HEOS media URI
+    """
+    if not is_media_uri(uri):
+        raise ValueError("uri is not a HEOS media URI")
+    parse_result = urlparse(uri)
+    path = parse_result.path.removeprefix("/").split("/", 2)
+    query = dict(
+        parse_qsl(parse_result.query, keep_blank_values=True, strict_parsing=True)
+    )
+    if "playable" in query:
+        return MediaItem(
+            source_id=int(path[0]),
+            type=MediaType(path[1]),
+            name=query["name"],
+            image_url=query["image_url"],
+            playable=query["playable"] == "True",
+            browsable=query["browsable"] == "True",
+            container_id=query.get("container_id"),
+            media_id=query.get("media_id"),
+            artist=query.get("artist"),
+            album=query.get("album"),
+            album_id=query.get("album_id"),
+            heos=None,
+        )
+    else:
+        return MediaMusicSource(
+            source_id=int(path[0]),
+            type=MediaType(path[1]),
+            name=query["name"],
+            image_url=query["image_url"],
+            available=query["available"] == "True",
+            service_username=query.get("service_username"),
+            heos=None,
+        )

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the utils module."""

--- a/tests/util/test_mediauri.py
+++ b/tests/util/test_mediauri.py
@@ -39,7 +39,7 @@ def test_to_from_media_uri_media(media: MediaItem, expected_uri: str) -> None:
     uri = mediauri.to_media_uri(media)
     assert uri == expected_uri
 
-    new_media = mediauri.from_media_uri(uri)
+    new_media, _ = mediauri.from_media_uri(uri)
     assert isinstance(new_media, MediaItem)
     assert new_media.source_id == media.source_id
     assert new_media.type == media.type
@@ -79,7 +79,7 @@ def test_to_from_media_uri_music_source(
     uri = mediauri.to_media_uri(media)
     assert uri == expected_uri
 
-    new_media = mediauri.from_media_uri(uri)
+    new_media, _ = mediauri.from_media_uri(uri)
     assert isinstance(new_media, MediaMusicSource)
     assert new_media.source_id == media.source_id
     assert new_media.type == media.type
@@ -87,3 +87,21 @@ def test_to_from_media_uri_music_source(
     assert new_media.image_url == media.image_url
     assert new_media.available == media.available
     assert new_media.service_username == media.service_username
+
+
+def test_to_from_media_uri_with_extra() -> None:
+    """Test extra data is passed correctly."""
+    uri = mediauri.to_media_uri(MediaItems.INPUT, {"range_start": 0, "range_end": 10})
+    assert (
+        uri
+        == "heos://media/-263109739/station?name=HEOS+Drive+-+AUX+In+1&image_url=&playable=True&browsable=False&media_id=inputs%2Faux_in_1&extra=%7B%22range_start%22%3A+0%2C+%22range_end%22%3A+10%7D"
+    )
+
+    new_media, extra = mediauri.from_media_uri(uri)
+    assert extra == {"range_start": 0, "range_end": 10}
+
+
+def test_from_media_uri_invalid_raises() -> None:
+    """Test the is_media_uri function."""
+    with pytest.raises(ValueError):
+        mediauri.from_media_uri("http://example.com")

--- a/tests/util/test_mediauri.py
+++ b/tests/util/test_mediauri.py
@@ -1,0 +1,89 @@
+"""Tests for the mediauri utility module."""
+
+import pytest
+
+from pyheos.media import MediaItem, MediaMusicSource
+from pyheos.util import mediauri
+from tests.common import MediaItems, MediaMusicSources
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected_result"),
+    [("heos://media/10/album", True), ("http://example.com", False)],
+)
+def test_is_media_uri(uri: str, expected_result: bool) -> None:
+    """Test the is_media_uri function."""
+    assert mediauri.is_media_uri(uri) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("media", "expected_uri"),
+    [
+        (
+            MediaItems.ALBUM,
+            "heos://media/10/album?name=After+Hours&image_url=http%3A%2F%2Fresources.wimpmusic.com%2Fimages%2Fbbe7f53c%2F44f0%2F41ba%2F873f%2F743e3091adde%2F160x160.jpg&playable=True&browsable=True&container_id=LIBALBUM-134788273&artist=The+Weeknd",
+        ),
+        (
+            MediaItems.INPUT,
+            "heos://media/-263109739/station?name=HEOS+Drive+-+AUX+In+1&image_url=&playable=True&browsable=False&media_id=inputs%2Faux_in_1",
+        ),
+        (
+            MediaItems.SONG,
+            "heos://media/10/song?name=Imaginary+Parties&image_url=http%3A%2F%2Fresources.wimpmusic.com%2Fimages%2F7e7bacc1%2F3e75%2F4761%2Fa822%2F9342239edfa0%2F640x640.jpg&playable=True&browsable=False&container_id=123&media_id=456&artist=Superfruit&album=Future+Friends&album_id=78374740",
+        ),
+    ],
+    ids=["album", "input", "song"],
+)
+def test_to_from_media_uri_media(media: MediaItem, expected_uri: str) -> None:
+    """Test media items are rendered as a URI string correctly."""
+    uri = mediauri.to_media_uri(media)
+    assert uri == expected_uri
+
+    new_media = mediauri.from_media_uri(uri)
+    assert isinstance(new_media, MediaItem)
+    assert new_media.source_id == media.source_id
+    assert new_media.type == media.type
+    assert new_media.name == media.name
+    assert new_media.image_url == media.image_url
+    assert new_media.playable == media.playable
+    assert new_media.browsable == media.browsable
+    assert new_media.container_id == media.container_id
+    assert new_media.media_id == media.media_id
+    assert new_media.artist == media.artist
+    assert new_media.album == media.album
+    assert new_media.album_id == media.album_id
+
+
+@pytest.mark.parametrize(
+    ("media", "expected_uri"),
+    [
+        (
+            MediaMusicSources.FAVORITES,
+            "heos://media/1028/heos_service?name=Favorites&image_url=https%3A%2F%2Fproduction.ws.skyegloup.com%3A443%2Fmedia%2Fimages%2Fservice%2Flogos%2Fmusicsource_logo_favorites.png&available=True",
+        ),
+        (
+            MediaMusicSources.TIDAL,
+            "heos://media/10/music_service?name=Tidal&image_url=https%3A%2F%2Fproduction.ws.skyegloup.com%3A443%2Fmedia%2Fimages%2Fservice%2Flogos%2Ftidal.png&available=True&service_username=user%40example.com",
+        ),
+        (
+            MediaMusicSources.PANDORA,
+            "heos://media/1/music_service?name=Pandora&image_url=https%3A%2F%2Fproduction.ws.skyegloup.com%3A443%2Fmedia%2Fimages%2Fservice%2Flogos%2Fpandora.png&available=False",
+        ),
+    ],
+    ids=["favorites", "tidal", "pandora"],
+)
+def test_to_from_media_uri_music_source(
+    media: MediaMusicSource, expected_uri: str
+) -> None:
+    """Test media items are rendered as a URI string correctly."""
+    uri = mediauri.to_media_uri(media)
+    assert uri == expected_uri
+
+    new_media = mediauri.from_media_uri(uri)
+    assert isinstance(new_media, MediaMusicSource)
+    assert new_media.source_id == media.source_id
+    assert new_media.type == media.type
+    assert new_media.name == media.name
+    assert new_media.image_url == media.image_url
+    assert new_media.available == media.available
+    assert new_media.service_username == media.service_username


### PR DESCRIPTION
## Description:
Adds a new utility module for serializing and deserializing media items to/from URIs. This is useful to represent these instances as a string.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)