### PR TITLE
Add auto-failover feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This class encapsulates the options and configuration for connecting to a HEOS s
 - `events: bool`: Set to `True` to enable event updates, `False` to disable. The default is `True`.
 - `all_progress_events: bool`: Set to `True` to receive media progress events, `False` to only receive media changed events. The default is `True`.
 - `dispatcher: pyheos.Dispatcher | None`: The dispatcher instance to use for event callbacks. If not provided, an internally created instance will be used.
+- `auto_failover: bool`: Set to True to automatically failover to other hosts if the connection is lost. The default is False. Used in conjunction with `auto_failover_hosts`.
+- `auto_failover_hosts: Sequence[str]`: A sequence of host names or IP addresses of other hosts in the HEOS system. The default is an empty list, which will be populated automatically from the system information.
 - `auto_reconnect: bool`: Set to `True` to automatically reconnect if the connection is lost. The default is `False`. Used in conjunction with `auto_reconnect_delay`.
 - `auto_reconnect_delay: float`: The number of seconds to wait before attempting to reconnect upon a connection failure. The default is `DEFAULT_RECONNECT_DELAY = 10.0`. Used in conjunction with `auto_reconnect`.
 - `auto_reconnect_max_attempts: float`: The maximum number of reconnection attempts before giving up. Set to `0` for unlimited attempts. The default is `0` (unlimited).

--- a/pyheos/command/connection.py
+++ b/pyheos/command/connection.py
@@ -1,6 +1,6 @@
 """Define the connection mixin module."""
 
-from pyheos.connection import AutoReconnectingConnection
+from pyheos.connection import AutoFailoverConnection
 from pyheos.options import HeosOptions
 from pyheos.types import ConnectionState
 
@@ -11,7 +11,7 @@ class ConnectionMixin:
     def __init__(self, options: HeosOptions) -> None:
         """Init a new instance of the ConnectionMixin."""
         self._options = options
-        self._connection = AutoReconnectingConnection(
+        self._connection = AutoFailoverConnection(
             options.host,
             timeout=options.timeout,
             reconnect=options.auto_reconnect,
@@ -19,6 +19,8 @@ class ConnectionMixin:
             reconnect_max_attempts=options.auto_reconnect_max_attempts,
             heart_beat=options.heart_beat,
             heart_beat_interval=options.heart_beat_interval,
+            failover=False,
+            failover_hosts=[],
         )
 
     @property

--- a/pyheos/command/connection.py
+++ b/pyheos/command/connection.py
@@ -19,11 +19,16 @@ class ConnectionMixin:
             reconnect_max_attempts=options.auto_reconnect_max_attempts,
             heart_beat=options.heart_beat,
             heart_beat_interval=options.heart_beat_interval,
-            failover=False,
-            failover_hosts=[],
+            failover=options.auto_failover,
+            failover_hosts=options.auto_failover_hosts,
         )
 
     @property
     def connection_state(self) -> ConnectionState:
         """Get the state of the connection."""
         return self._connection.state
+
+    @property
+    def current_host(self) -> str:
+        """Get the host name or IP address."""
+        return self._connection.host

--- a/pyheos/connection.py
+++ b/pyheos/connection.py
@@ -6,6 +6,7 @@ from abc import ABC
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import suppress
 from datetime import datetime, timedelta
+from itertools import cycle
 from typing import TYPE_CHECKING, Any, Final
 
 from pyheos.command import COMMAND_HEART_BEAT, COMMAND_REBOOT
@@ -51,6 +52,11 @@ class ConnectionBase(ABC):
     def state(self) -> ConnectionState:
         """Get the current state of the connection."""
         return self._state
+
+    @property
+    def host(self) -> str:
+        """Get the host of the connection."""
+        return self._host
 
     def add_on_event(self, callback: Callable[[HeosMessage], Awaitable[None]]) -> None:
         """Add a callback to be invoked when an event is received."""
@@ -310,11 +316,9 @@ class HeartBeatBehavior(ConnectionBase, ABC):
         await super()._on_connected()
 
 
-class AutoReconnectingConnection(HeartBeatBehavior):
+class AutoReconnectingBehavior(HeartBeatBehavior, ABC):
     """
     Define a class that manages the connection state and automatically reconnects on failure.
-
-    This class adds heartbeat functionality and auto-reconnect logic.
     """
 
     def __init__(
@@ -322,13 +326,13 @@ class AutoReconnectingConnection(HeartBeatBehavior):
         host: str,
         *,
         timeout: float,
+        heart_beat: bool = True,
+        heart_beat_interval: float,
         reconnect: bool = True,
         reconnect_delay: float,
         reconnect_max_attempts: int,
-        heart_beat: bool = True,
-        heart_beat_interval: float,
     ) -> None:
-        """Init a new instance of the AutoReconnectingConnection class."""
+        """Init a new instance of the AutoReconnectingBehavior class."""
         super().__init__(
             host,
             timeout=timeout,
@@ -339,15 +343,18 @@ class AutoReconnectingConnection(HeartBeatBehavior):
         self._reconnect_delay = reconnect_delay
         self._reconnect_max_attempts = reconnect_max_attempts
 
-    async def _attempt_reconnect(self) -> None:
+    async def _attempt_reconnect(self, delay: float, max_attempts: int) -> None:
         """Attempt to reconnect after disconnection from error."""
         self._state = ConnectionState.RECONNECTING
         attempts = 0
-        unlimited_attempts = self._reconnect_max_attempts == 0
-        delay = min(self._reconnect_delay, MAX_RECONNECT_DELAY)
-        while (attempts < self._reconnect_max_attempts) or unlimited_attempts:
-            _LOGGER.debug("Waiting %s seconds before attempting to reconnect", delay)
-            await asyncio.sleep(delay)
+        unlimited_attempts = max_attempts == 0
+        delay = min(delay, MAX_RECONNECT_DELAY)
+        while (attempts < max_attempts) or unlimited_attempts:
+            if delay > 0:
+                _LOGGER.debug(
+                    "Waiting %s seconds before attempting to reconnect", delay
+                )
+                await asyncio.sleep(delay)
             _LOGGER.debug("Attempting reconnect #%s to %s", (attempts + 1), self._host)
             try:
                 await self.connect()
@@ -360,7 +367,71 @@ class AutoReconnectingConnection(HeartBeatBehavior):
     async def _on_disconnected(self, due_to_error: bool = False) -> None:
         """Handle when the connection is lost. Invoked after the connection has been reset."""
         if due_to_error and self._reconnect:
-            self._register_task(self._attempt_reconnect(), "Reconnect")
+            self._register_task(
+                self._attempt_reconnect(
+                    self._reconnect_delay, self._reconnect_max_attempts
+                ),
+                "Reconnect",
+            )
+        await super()._on_disconnected(due_to_error)
+
+
+class AutoFailoverConnection(AutoReconnectingBehavior):
+    """
+    Define a class that manages the connection state and fails over to a backup host on failure.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        timeout: float,
+        heart_beat: bool = True,
+        heart_beat_interval: float,
+        reconnect: bool = True,
+        reconnect_delay: float,
+        reconnect_max_attempts: int,
+        failover: bool,
+        failover_hosts: list[str],
+    ) -> None:
+        """Init a new instance of the AutoFailoverConnection class."""
+        super().__init__(
+            host,
+            timeout=timeout,
+            heart_beat=heart_beat,
+            heart_beat_interval=heart_beat_interval,
+            reconnect=reconnect,
+            reconnect_delay=reconnect_delay,
+            reconnect_max_attempts=reconnect_max_attempts,
+        )
+        self._failover = failover
+        self._failover_hosts = failover_hosts
+
+    async def _attempt_failover(self) -> None:
+        """Attempt to fail over to a backup host."""
+        self._state = ConnectionState.RECONNECTING
+
+        failover_hosts = cycle([self._host, *self._failover_hosts])
+        assert self._host == next(failover_hosts)
+
+        # First attempt to reconnect to the current host
+        await self._attempt_reconnect(1.0, 1)
+
+        while self._state is not ConnectionState.CONNECTED:
+            old_host = self._host
+            self._host = next(failover_hosts)
+            _LOGGER.debug(
+                "Failed to connect to %s. Trying next host %s", old_host, self._host
+            )
+            await self._attempt_reconnect(0, 1)
+
+    async def _on_disconnected(self, due_to_error: bool = False) -> None:
+        """Handle when the connection is lost. Invoked after the connection has been reset."""
+        if due_to_error and self._failover and self._failover_hosts:
+            self._register_task(self._attempt_failover(), "Failover")
+            # Call super on heart beat to prevent the reconnect logic from running
+            await super(HeartBeatBehavior, self)._on_disconnected(due_to_error)
+            return
         await super()._on_disconnected(due_to_error)
 
 

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -293,7 +293,7 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
 
     async def _update_failover_hosts(self) -> None:
         """Update the failover hosts in the connection."""
-        if not self._options.auto_failover or not self._options.auto_failover_hosts:
+        if not self._options.auto_failover or self._options.auto_failover_hosts:
             return
         system_info = await self.get_system_info()
         hosts = system_info.get_ip_addresses()

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -50,7 +50,6 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
             dispatcher: The dispatcher instance to use for event callbacks. If not provided, an internally created instance will be used.
             auto_failover: Set to True to automatically failover to other hosts if the connection is lost. The default is False. Used in conjunction with auto_failover_hosts.
             auto_failover_hosts: A list of host names or IP addresses to use for failover. Used in conjunction with auto_failover.
-            auto_populate_failover_hosts: Set to True to automatically populate the failover hosts list with the host name or IP address of the connected device. The default is False. Used in conjunction with auto_failover.
             auto_reconnect: Set to True to automatically reconnect if the connection is lost. The default is False. Used in conjunction with auto_reconnect_delay.
             auto_reconnect_delay: The delay in seconds before attempting to reconnect. The default is 10 seconds. Used in conjunction with auto_reconnect.
             auto_reconnect_max_attempts: The maximum number of reconnection attempts before giving up. Set to 0 for unlimited attempts. The default is 0 (unlimited).
@@ -294,10 +293,7 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
 
     async def _update_failover_hosts(self) -> None:
         """Update the failover hosts in the connection."""
-        if (
-            not self._options.auto_failover
-            or not self._options.auto_populate_failover_hosts
-        ):
+        if not self._options.auto_failover or not self._options.auto_failover_hosts:
             return
         system_info = await self.get_system_info()
         hosts = system_info.get_ip_addresses()

--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -1,6 +1,7 @@
 """Define the heos manager module."""
 
 import logging
+from contextlib import suppress
 from typing import Any, Final
 
 from pyheos.command import COMMAND_SIGN_IN
@@ -47,6 +48,9 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
             events: Set to True to enable event updates, False to disable. The default is True.
             all_progress_events: Set to True to receive media progress events, False to only receive media changed events. The default is True.
             dispatcher: The dispatcher instance to use for event callbacks. If not provided, an internally created instance will be used.
+            auto_failover: Set to True to automatically failover to other hosts if the connection is lost. The default is False. Used in conjunction with auto_failover_hosts.
+            auto_failover_hosts: A list of host names or IP addresses to use for failover. Used in conjunction with auto_failover.
+            auto_populate_failover_hosts: Set to True to automatically populate the failover hosts list with the host name or IP address of the connected device. The default is False. Used in conjunction with auto_failover.
             auto_reconnect: Set to True to automatically reconnect if the connection is lost. The default is False. Used in conjunction with auto_reconnect_delay.
             auto_reconnect_delay: The delay in seconds before attempting to reconnect. The default is 10 seconds. Used in conjunction with auto_reconnect.
             auto_reconnect_max_attempts: The maximum number of reconnection attempts before giving up. Set to 0 for unlimited attempts. The default is 0 (unlimited).
@@ -171,6 +175,9 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
             # Determine the logged in user
             await self.check_account()
 
+        # Populate failover hosts if enabled
+        await self._update_failover_hosts()
+
         await self.register_for_change_events(self._options.events)
 
         # Refresh players and mark available
@@ -233,8 +240,10 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
     async def _on_event_heos(self, event: HeosMessage) -> None:
         """Process a HEOS system event."""
         result: PlayerUpdateResult | None = None
-        if event.command == const.EVENT_PLAYERS_CHANGED and self._players_loaded:
-            result = await self.load_players()
+        if event.command == const.EVENT_PLAYERS_CHANGED:
+            await self._update_failover_hosts()
+            if self._players_loaded:
+                result = await self.load_players()
         elif (
             event.command == const.EVENT_SOURCES_CHANGED and self._music_sources_loaded
         ):
@@ -282,6 +291,19 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
                 return_exceptions=True,
             )
             _LOGGER.debug("Event received for group %s: %s", group_id, event.command)
+
+    async def _update_failover_hosts(self) -> None:
+        """Update the failover hosts in the connection."""
+        if (
+            not self._options.auto_failover
+            or not self._options.auto_populate_failover_hosts
+        ):
+            return
+        system_info = await self.get_system_info()
+        hosts = system_info.get_ip_addresses()
+        with suppress(ValueError):
+            hosts.remove(self._connection.host)
+        self._connection.failover_hosts = hosts
 
     @property
     def dispatcher(self) -> Dispatcher:

--- a/pyheos/options.py
+++ b/pyheos/options.py
@@ -1,5 +1,6 @@
 """Define the options module."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 
 from pyheos import const
@@ -40,3 +41,6 @@ class HeosOptions:
     heart_beat: bool = field(default=True, kw_only=True)
     heart_beat_interval: float = field(default=const.DEFAULT_HEART_BEAT, kw_only=True)
     credentials: Credentials | None = field(default=None, kw_only=True)
+    auto_failover: bool = field(default=False, kw_only=True)
+    auto_failover_hosts: Sequence[str] = field(default_factory=list, kw_only=True)
+    auto_populate_failover_hosts: bool = field(default=True, kw_only=True)

--- a/pyheos/options.py
+++ b/pyheos/options.py
@@ -24,6 +24,8 @@ class HeosOptions:
         auto_reconnect: Set to True to automatically reconnect if the connection is lost. The default is False. Used in conjunction with auto_reconnect_delay.
         auto_reconnect_delay: The delay in seconds before attempting to reconnect. The default is 10 seconds. Used in conjunction with auto_reconnect.
         credentials: credentials to use to automatically sign-in to the HEOS account upon successful connection. If not provided, the account will not be signed in.
+        auto_failover: Set to True to automatically failover to other hosts if the connection is lost. The default is False. Used in conjunction with auto_failover_hosts.
+        auto_failover_hosts: A list of host names or IP addresses to use for failover. Used in conjunction with auto_failover.
     """
 
     host: str
@@ -43,4 +45,3 @@ class HeosOptions:
     credentials: Credentials | None = field(default=None, kw_only=True)
     auto_failover: bool = field(default=False, kw_only=True)
     auto_failover_hosts: Sequence[str] = field(default_factory=list, kw_only=True)
-    auto_populate_failover_hosts: bool = field(default=True, kw_only=True)

--- a/pyheos/system.py
+++ b/pyheos/system.py
@@ -105,3 +105,11 @@ class HeosSystem:
         self.connected_to_preferred_host = (
             self.host is not None and self.host in self.preferred_hosts
         )
+
+    def get_ip_addresses(self) -> list[str]:
+        """Get a list of IP addresses for the hosts."""
+        hosts = sorted(
+            [host for host in self.hosts if host.ip_address is not None],
+            key=lambda x: (x.preferred_host, *_safe_ip_address(x.ip_address)),
+        )
+        return [host.ip_address for host in hosts]  # type: ignore[misc]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -277,11 +277,11 @@ class MockHeosDevice:
         self._matchers: list[CommandMatcher] = []
         self.modifiers: list[CommandModifier] = []
 
-    async def start(self) -> None:
+    async def start(self, address: str = "127.0.0.1") -> None:
         """Start the heos server."""
         self._started = True
         self._server = await asyncio.start_server(
-            self._handle_connection, "127.0.0.1", CLI_PORT
+            self._handle_connection, address, CLI_PORT
         )
 
         self.register(c.COMMAND_ACCOUNT_CHECK, None, "system.check_account")

--- a/tests/test_heos_autofailover.py
+++ b/tests/test_heos_autofailover.py
@@ -20,7 +20,6 @@ async def test_failover_hosts_updated_on_connection(
             auto_reconnect=True,
             auto_reconnect_delay=0.1,
             auto_failover=True,
-            auto_populate_failover_hosts=True,
             heart_beat=False,
         )
     )
@@ -42,7 +41,6 @@ async def test_failover_hosts_updated_on_players_changed(
             auto_reconnect=True,
             auto_reconnect_delay=0.1,
             auto_failover=True,
-            auto_populate_failover_hosts=True,
             heart_beat=False,
         )
     )
@@ -61,6 +59,27 @@ async def test_failover_hosts_updated_on_players_changed(
     await heos.disconnect()
 
 
+async def test_failover_hosts_manually_provided_hosts(
+    mock_device: MockHeosDevice,
+) -> None:
+    """Test manually provided hosts are preserved."""
+    heos = Heos(
+        HeosOptions(
+            "127.0.0.1",
+            timeout=0.1,
+            auto_reconnect=True,
+            auto_reconnect_delay=0.1,
+            auto_failover=True,
+            auto_failover_hosts=["127.0.0.3"],
+            heart_beat=False,
+        )
+    )
+    await heos.connect()
+    assert heos.connection_state == ConnectionState.CONNECTED
+    assert heos._connection.failover_hosts == ["127.0.0.3"]
+    await heos.disconnect()
+
+
 @calls_command("player.get_players")
 async def test_failover(mock_device: MockHeosDevice) -> None:
     """Test reconnect while waiting for events/responses."""
@@ -72,7 +91,6 @@ async def test_failover(mock_device: MockHeosDevice) -> None:
             auto_reconnect_delay=0.1,
             heart_beat=False,
             auto_failover=True,
-            auto_populate_failover_hosts=True,
         )
     )
 
@@ -119,7 +137,6 @@ async def test_failover_retries_current_host(mock_device: MockHeosDevice) -> Non
             auto_reconnect_delay=0.1,
             heart_beat=False,
             auto_failover=True,
-            auto_populate_failover_hosts=True,
         )
     )
 

--- a/tests/test_heos_autofailover.py
+++ b/tests/test_heos_autofailover.py
@@ -1,0 +1,155 @@
+"""Define module for testing autofailover functionality."""
+
+from pyheos import command as c
+from pyheos.const import EVENT_PLAYERS_CHANGED
+from pyheos.heos import Heos
+from pyheos.options import HeosOptions
+from pyheos.types import ConnectionState, SignalHeosEvent, SignalType
+from tests import MockHeosDevice, calls_command, connect_handler
+
+
+@calls_command("player.get_players")
+async def test_failover_hosts_updated_on_connection(
+    mock_device: MockHeosDevice,
+) -> None:
+    """Test failover hosts are populated after connecting."""
+    heos = Heos(
+        HeosOptions(
+            "127.0.0.1",
+            timeout=0.1,
+            auto_reconnect=True,
+            auto_reconnect_delay=0.1,
+            auto_failover=True,
+            auto_populate_failover_hosts=True,
+            heart_beat=False,
+        )
+    )
+    await heos.connect()
+    assert heos.connection_state == ConnectionState.CONNECTED
+    assert heos._connection.failover_hosts == ["127.0.0.2"]
+    await heos.disconnect()
+
+
+@calls_command("player.get_players")
+async def test_failover_hosts_updated_on_players_changed(
+    mock_device: MockHeosDevice,
+) -> None:
+    """Test failover hosts are updated when players change."""
+    heos = Heos(
+        HeosOptions(
+            "127.0.0.1",
+            timeout=0.1,
+            auto_reconnect=True,
+            auto_reconnect_delay=0.1,
+            auto_failover=True,
+            auto_populate_failover_hosts=True,
+            heart_beat=False,
+        )
+    )
+    await heos.connect()
+
+    event = connect_handler(heos, SignalType.CONTROLLER_EVENT, EVENT_PLAYERS_CHANGED)
+    # Write event through mock device
+    mock_device.register(
+        c.COMMAND_GET_PLAYERS, None, "player.get_players_changed", replace=True
+    )
+    await mock_device.write_event("event.players_changed")
+
+    # Wait until the signal is set
+    await event.wait()
+    assert heos._connection.failover_hosts == ["127.0.0.3", "192.168.0.1"]
+    await heos.disconnect()
+
+
+@calls_command("player.get_players")
+async def test_failover(mock_device: MockHeosDevice) -> None:
+    """Test reconnect while waiting for events/responses."""
+    heos = Heos(
+        HeosOptions(
+            "127.0.0.1",
+            timeout=0.1,
+            auto_reconnect=True,
+            auto_reconnect_delay=0.1,
+            heart_beat=False,
+            auto_failover=True,
+            auto_populate_failover_hosts=True,
+        )
+    )
+
+    connect_signal = connect_handler(
+        heos, SignalType.HEOS_EVENT, SignalHeosEvent.CONNECTED
+    )
+    disconnect_signal = connect_handler(
+        heos, SignalType.HEOS_EVENT, SignalHeosEvent.DISCONNECTED
+    )
+
+    # Assert open and fires connected
+    await heos.connect()
+    assert connect_signal.is_set()
+    assert heos.connection_state == ConnectionState.CONNECTED
+    connect_signal.clear()
+
+    # Assert transitions to reconnecting and fires disconnect
+    await mock_device.stop()
+    await mock_device.start("127.0.0.2")
+    await disconnect_signal.wait()
+    assert heos.connection_state == ConnectionState.RECONNECTING  # type: ignore[comparison-overlap]
+
+    failover_task = next(  # type: ignore[unreachable]
+        task
+        for task in heos._connection._running_tasks
+        if task.get_name() == "Failover"
+    )
+    await connect_signal.wait()
+    assert heos.connection_state == ConnectionState.CONNECTED
+    assert heos.current_host == "127.0.0.2"
+
+    await failover_task  # Ensures task completes, otherwise disconnect cancels it
+    await heos.disconnect()
+
+
+@calls_command("player.get_players")
+async def test_failover_retries_current_host(mock_device: MockHeosDevice) -> None:
+    """Test failover first attempts to reconnect to the current host."""
+    heos = Heos(
+        HeosOptions(
+            "127.0.0.1",
+            timeout=0.1,
+            auto_reconnect=True,
+            auto_reconnect_delay=0.1,
+            heart_beat=False,
+            auto_failover=True,
+            auto_populate_failover_hosts=True,
+        )
+    )
+
+    connect_signal = connect_handler(
+        heos, SignalType.HEOS_EVENT, SignalHeosEvent.CONNECTED
+    )
+    disconnect_signal = connect_handler(
+        heos, SignalType.HEOS_EVENT, SignalHeosEvent.DISCONNECTED
+    )
+
+    # Assert open and fires connected
+    await heos.connect()
+    assert connect_signal.is_set()
+    assert heos.connection_state == ConnectionState.CONNECTED
+    connect_signal.clear()
+
+    # Assert transitions to reconnecting and fires disconnect
+    await mock_device.restart()
+    await disconnect_signal.wait()
+    assert heos.connection_state == ConnectionState.RECONNECTING  # type: ignore[comparison-overlap]
+
+    failover_task = next(  # type: ignore[unreachable]
+        task
+        for task in heos._connection._running_tasks
+        if task.get_name() == "Failover"
+    )
+
+    await connect_signal.wait()
+    assert heos.connection_state == ConnectionState.CONNECTED
+    assert heos.current_host == "127.0.0.1"
+
+    await failover_task  # Ensures task completes, otherwise disconnect cancels it
+    await heos.disconnect()


### PR DESCRIPTION
## Description:
Adds a new feature to automatically failover to alternate system hosts when the connected host goes down. When enabled, the connection will maintain a list of alternate hosts and cycle through them until connected. After a disconnection, it will first attempt to reconnect to the current host once before moving on to the next host. When the functionality is disabled (the default), or there are no alternate hosts, the connection will fallback to the previous reconnect logic.

Three new parameters have been added to HEOS options:
- `auto_failover: bool`: Set to True to automatically failover to other hosts if the connection is lost. The default is False.
- `auto_failover_hosts: Sequence[str]`: A sequence of failover host names. If not provided, they will be automatically populated and updated from available in the system.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)