### PR TITLE
Allow browsing unavailable sources

### DIFF
--- a/pyheos/command/browse.py
+++ b/pyheos/command/browse.py
@@ -180,8 +180,6 @@ class BrowseCommands(ConnectionMixin):
             A BrowseResult instance containing the items in the media item.
         """
         if isinstance(media, MediaMusicSource):
-            if not media.available:
-                raise ValueError("Source is not available to browse")
             return await self.browse(media.source_id)
         else:
             if not media.browsable:

--- a/tests/snapshots/test_heos.ambr
+++ b/tests/snapshots/test_heos.ambr
@@ -249,6 +249,62 @@
     'source_id': 1028,
   })
 # ---
+# name: test_browse_media_music_source_unavailable
+  dict({
+    'container_id': None,
+    'count': 3,
+    'items': list([
+      dict({
+        'album': None,
+        'album_id': None,
+        'artist': None,
+        'browsable': False,
+        'container_id': None,
+        'image_url': 'http://mediaserver-cont-ch1-1-v4v6.pandora.com/images/public/devicead/t/r/a/m/daartpralbumart_500W_500H.jpg',
+        'media_id': '3790855220637622543',
+        'name': 'Thumbprint Radio',
+        'playable': True,
+        'source_id': 1028,
+        'type': <MediaType.STATION: 'station'>,
+      }),
+      dict({
+        'album': None,
+        'album_id': None,
+        'artist': None,
+        'browsable': False,
+        'container_id': None,
+        'image_url': 'http://cdn-radiotime-logos.tunein.com/s7332q.png',
+        'media_id': 's7332',
+        'name': '99.5 | Classical MPR (Classical Music)',
+        'playable': True,
+        'source_id': 1028,
+        'type': <MediaType.STATION: 'station'>,
+      }),
+      dict({
+        'album': None,
+        'album_id': None,
+        'artist': None,
+        'browsable': False,
+        'container_id': None,
+        'image_url': 'http://mediaserver-cont-dc6-2-v4v6.pandora.com/images/public/int/4/0/8/2/00602577432804_500W_500H.jpg',
+        'media_id': '1935916853323522319',
+        'name': "Today's Hits Radio",
+        'playable': True,
+        'source_id': 1028,
+        'type': <MediaType.STATION: 'station'>,
+      }),
+    ]),
+    'options': list([
+      dict({
+        'context': 'browse',
+        'id': 20,
+        'name': 'Remove from HEOS Favorites',
+      }),
+    ]),
+    'returned': 3,
+    'source_id': 1028,
+  })
+# ---
 # name: test_get_favorites
   dict({
     1: dict({

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -24,6 +24,7 @@ from pyheos.const import (
     EVENT_USER_CHANGED,
     MUSIC_SOURCE_AUX_INPUT,
     MUSIC_SOURCE_FAVORITES,
+    MUSIC_SOURCE_PANDORA,
     MUSIC_SOURCE_PLAYLISTS,
     MUSIC_SOURCE_TUNEIN,
 )
@@ -1237,13 +1238,18 @@ async def test_browse_media_music_source(
     assert result == snapshot
 
 
-async def test_browse_media_music_source_unavailable_rasises(
+@calls_command(
+    "browse.browse_favorites",
+    {c.ATTR_SOURCE_ID: MUSIC_SOURCE_PANDORA},
+)
+async def test_browse_media_music_source_unavailable(
+    heos: Heos,
     media_music_source_unavailable: MediaMusicSource,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test browse with an unavailable MediaMusicSource raises."""
-    heos = Heos(HeosOptions("127.0.0.1"))
-    with pytest.raises(ValueError, match="Source is not available to browse"):
-        await heos.browse_media(media_music_source_unavailable)
+    result = await heos.browse_media(media_music_source_unavailable)
+    assert result == snapshot
 
 
 @calls_command(


### PR DESCRIPTION
## Description:
Allow browsing of `MediaMusicSource` instances that are not `available`, since they can still be enumerated, and in the case of TuneIn, browsed and played. 

**Related issue (if applicable):** fixes #113

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)