### PR TITLE
Update music sources when user changes

### DIFF
--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -252,6 +252,8 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
                 self._signed_in_username = event.get_message_value(c.ATTR_USER_NAME)
             else:
                 self._signed_in_username = None
+            if self._music_sources_loaded:
+                await self.get_music_sources(refresh=True)
         elif event.command == const.EVENT_GROUPS_CHANGED:
             if self._players_loaded:
                 # Ensure player group ID attributes (i.e. group_id) are update


### PR DESCRIPTION
## Description:
This ensures that loaded music sources are refreshed when a user changed event is received, as that changes the availability of the items.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)