### PR TITLE
Only refresh loaded music sources on user logout

### DIFF
--- a/pyheos/heos.py
+++ b/pyheos/heos.py
@@ -252,8 +252,10 @@ class Heos(SystemCommands, BrowseCommands, GroupCommands, PlayerCommands):
                 self._signed_in_username = event.get_message_value(c.ATTR_USER_NAME)
             else:
                 self._signed_in_username = None
-            if self._music_sources_loaded:
-                await self.get_music_sources(refresh=True)
+                # HEOS does not send a sources changed event upon logout
+                if self._music_sources_loaded:
+                    await self.get_music_sources(refresh=True)
+
         elif event.command == const.EVENT_GROUPS_CHANGED:
             if self._players_loaded:
                 # Ensure player group ID attributes (i.e. group_id) are update

--- a/tests/test_heos.py
+++ b/tests/test_heos.py
@@ -1078,10 +1078,10 @@ async def test_sources_changed_event(mock_device: MockHeosDevice, heos: Heos) ->
 
 
 @calls_command("browse.get_music_sources", {})
-async def test_sources_update_after_user_changed_event(
+async def test_sources_update_after_user_signed_out(
     mock_device: MockHeosDevice, heos: Heos
 ) -> None:
-    """Test music sources update when the user changes."""
+    """Test music sources update when the user signed out."""
     await heos.get_music_sources()
     signal = asyncio.Event()
 


### PR DESCRIPTION
## Description:
HEOS sends a sources changed event when the user logs in, but not when they log out, so we only need to refresh it during logout.
 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)