### PR TITLE
Add unknown play state enumeration

### DIFF
--- a/pyheos/command/player.py
+++ b/pyheos/command/player.py
@@ -175,6 +175,8 @@ class PlayerCommands(ConnectionMixin):
 
         References:
             4.2.4 Set Play State"""
+        if state is PlayState.UNKNOWN:
+            raise ValueError("'state' can not be set to 'unknown'")
         await self._connection.command(
             HeosCommand(
                 c.COMMAND_SET_PLAY_STATE,

--- a/pyheos/types.py
+++ b/pyheos/types.py
@@ -78,6 +78,7 @@ class PlayState(StrEnum):
     PLAY = "play"
     PAUSE = "pause"
     STOP = "stop"
+    UNKNOWN = "unknown"
 
 
 class SignalType(StrEnum):

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -106,6 +106,12 @@ async def test_set_state(player: HeosPlayer, state: PlayState) -> None:
     await player.set_state(state)
 
 
+async def test_set_state_unknown_raises(player: HeosPlayer) -> None:
+    """Test setting play state to unknown raises."""
+    with pytest.raises(ValueError):
+        await player.set_state(PlayState.UNKNOWN)
+
+
 @calls_command(
     "player.set_play_state",
     {c.ATTR_PLAYER_ID: 1, c.ATTR_STATE: PlayState.PLAY},


### PR DESCRIPTION
## Description:
The result of `get_play_state` may return `unknown`, which was not defined in the enumeration. This appears to occur when media has been paused for an extended time and HEOS itself loses track of the state of the play. This change the unknown option to the enumeration and prevents setting that in `set_play_state`.

**Related issue (if applicable):** Discovered in https://github.com/home-assistant/core/issues/142420

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [X] `README.MD` updated (if necessary)