### PR TITLE
Replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/pyheos/dispatch.py
+++ b/pyheos/dispatch.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import functools
+import inspect
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Sequence
@@ -26,7 +27,7 @@ def _is_coroutine_function(func: TargetType) -> bool:
 
     while isinstance(func, functools.partial):
         func = func.func
-    return asyncio.iscoroutinefunction(func)
+    return inspect.iscoroutinefunction(func)
 
 
 def _filter_args(


### PR DESCRIPTION
## Description:
Python 3.14 will deprecated `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` which has been available for some time now.

https://docs.python.org/3.14/deprecations/pending-removal-in-3.16.html
https://docs.python.org/3.14/library/inspect.html#inspect.iscoroutinefunction