### PR TITLE
Minor docstring updates

### DIFF
--- a/pyheos/player.py
+++ b/pyheos/player.py
@@ -439,12 +439,12 @@ class HeosPlayer(RemoveHeosFieldABC):
         )
 
     async def play_next(self) -> None:
-        """Clear the queue of the player."""
+        """Plays the next item in the queue."""
         assert self.heos, "Heos instance not set"
         await self.heos.player_play_next(self.player_id)
 
     async def play_previous(self) -> None:
-        """Clear the queue of the player."""
+        """Plays the previous item in the queue."""
         assert self.heos, "Heos instance not set"
         await self.heos.player_play_previous(self.player_id)
 


### PR DESCRIPTION
## Description:
When working on a HEOS provider in Music Assistant, I noticed the docstrings for `play_next` and `play_previous` where incorrect.

**Related issue (if applicable):** fixes #<pyheos issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] Tests have been added/updated. No exclusions in `.coveragerc` permitted.
  - [ ] `README.MD` updated (if necessary)